### PR TITLE
Modify to read RootConfig file of js ext

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,5 @@ package-lock.json
 yarn.lock
 
 .node-version
+
+*.tgz

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@
   ```
   ```ts
   // ver.yowu
-  import pinpointNodeAgent, { ConfigOption } from 'pinpoint-node-agent';
+  import pinpointNodeAgent, { ConfigOption } from '@uyu423/pinpoint-node-agent';
 
+  // bootstarp agent on your application level
   pinpointNodeAgent({
     applicationName: 'somehing-name',
     agentId: 'something-id',

--- a/README.md
+++ b/README.md
@@ -1,4 +1,34 @@
-# Pinpoint Node.js Agent
+# Pinpoint Node.js Agent ver.Yowu
+
+- upstream package is [pinpoint-node-agent](https://www.npmjs.com/package/pinpoint-node-agent)
+
+## Diffrence by original Pinpoint Node.js Agent
+
+- Include simple `*.d.ts` file. (for TypeScript)
+- supported read `./pinpoint-config.js` [#9](https://github.com/pinpoint-apm/pinpoint-node-agent/pull/9)
+- Change Agent init Method
+  ```ts
+  // original
+  import 'pinpoint-node-agent`
+  ```
+  ```ts
+  // ver.yowu
+  import pinpointNodeAgent, { ConfigOption } from 'pinpoint-node-agent';
+
+  pinpointNodeAgent({
+    applicationName: 'somehing-name',
+    agentId: 'something-id',
+    collectorIp: 'somthing-ip',
+  } as ConfigOption)
+  ```
+- some bug fix
+  - [fixed Config init processing bug #10](https://github.com/pinpoint-apm/pinpoint-node-agent/pull/10)
+
+<br/>
+<hr/>
+<br/>
+
+# (Origin README) Pinpoint Node.js Agent
 This is the official Node.js agent for [Pinpoint](https://github.com/naver/pinpoint).
 
 If you have any feedback or questions,

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-declare module 'pinpoint-node-agent' {
+declare module '@uyu423/pinpoint-node-agent' {
   function PinpointNodeAgent(options?: ConfigOption): Agent
 
   interface ConfigOption {

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,33 @@
+declare module 'pinpoint-node-agent' {
+  function PinpointNodeAgent(options?: ConfigOption): Agent
+
+  interface ConfigOption {
+    /** Agent Id (uniq) */
+    agentId?: string,
+    /** Application Name */
+    applicationName?: string,
+    serviceType?: number,
+    /** Collector Sevice IP or Hostname */
+    collectorIp?: string,
+    collectorTcpPort?: number,
+    collectorStatPort?: number,
+    collectorSpanPort?: number,
+    sampling?: boolean,
+    sampleRate?: number,
+    httpStatusCodeErrors?: string[],
+    logLevel?: string,
+    enabledDataSending?: boolean,
+    enabledStatsMonitor?: boolean,
+    enabledActiveThreadCount?: boolean,
+    express?: boolean,
+    koa?: boolean,
+    mongo?: boolean,
+    redis?: boolean,
+    enable?: boolean,
+    container?: string,
+  }
+
+  interface Agent {}
+}
+
+export default PinpointNodeAgent;

--- a/index.js
+++ b/index.js
@@ -6,6 +6,20 @@
 
 'use strict'
 
-const Agent = require('./lib/agent')
-const agent = new Agent()
-module.exports = agent
+let agent;
+
+module.exports = (options) => {
+  /**
+   * Modified to receive option at Application Level
+   * 
+   * @version 0.8.0-ver.yowu
+   */ 
+  if (agent !== undefined) {
+    return agent;
+  }
+
+  const Agent = require('./lib/agent')
+  agent = new Agent(options);
+
+  return agent;
+}

--- a/lib/config.js
+++ b/lib/config.js
@@ -115,8 +115,8 @@ const init = (initOptions = {}) => {
       readConfigJson(defaultConfig),
       readConfigJson(readRootConfigFile()),
       readFromEnv(),
-      readConfigJson(initOptions))
-
+      initOptions)
+    
   log.init(agentConfig.logLevel)
 
   Object.entries(REQUIRE_CONFIG).forEach(([propertyName, description]) => {

--- a/lib/config.js
+++ b/lib/config.js
@@ -165,9 +165,10 @@ const readConfigJson = (formattedConfig) => {
 }
 
 const readRootConfigFile = () => {
-  const fileName = 'pinpoint-config.json'
-  const fileFullPath = ROOT_PATH + '/' + fileName
-  if (fs.existsSync(fileFullPath)) {
+  const fileName = 'pinpoint-config'
+  const fileFullPath = path.join(ROOT_PATH, '/', fileName)
+
+  if (fs.existsSync(fileFullPath.concat('.json')) || fs.existsSync(fileFullPath.concat('.js'))) {
     return require(fileFullPath)
   }
   return {}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uyu423/pinpoint-node-agent",
-  "version": "0.8.1-ver.yowu",
+  "version": "0.8.2-ver.yowu",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/tape ./test/**/*.test.js"

--- a/package.json
+++ b/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "pinpoint-node-agent",
-  "version": "0.8.0-ver.yowu",
+  "name": "@uyu423/pinpoint-node-agent",
+  "version": "0.8.1-ver.yowu",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/tape ./test/**/*.test.js"
   },
-  "description": "Pinpoint node agent provided by NAVER",
+  "description": "Pinpoint node agent provided by NAVER (Personalized version)",
   "repository": {
     "type": "git",
-    "url": "https://github.com/pinpoint-apm/pinpoint-node-agent"
+    "url": "https://github.com/uyu423/pinpoint-node-agent"
   },
   "contributors": [
     "Lee Jun Hee <jundol.lee@navercorp.com> (https://github.com/intojun)",
@@ -23,10 +23,6 @@
       "url": "http://www.apache.org/licenses/LICENSE-2.0"
     }
   ],
-  "bugs": {
-    "url": "https://github.com/pinpoint-apm/pinpoint-node-agent/issues"
-  },
-  "homepage": "https://github.com/pinpoint-apm/pinpoint-node-agent",
   "engines": {
     "node": ">=8.2.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uyu423/pinpoint-node-agent",
-  "version": "0.8.2-ver.yowu",
+  "version": "0.8.3-ver.yowu",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/tape ./test/**/*.test.js"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pinpoint-node-agent",
-  "version": "0.7.1",
+  "version": "0.8.0-ver.yowu",
   "main": "index.js",
   "scripts": {
     "test": "./node_modules/.bin/tape ./test/**/*.test.js"
@@ -13,7 +13,8 @@
   "contributors": [
     "Lee Jun Hee <jundol.lee@navercorp.com> (https://github.com/intojun)",
     "Bae Keun Bae <with.earth.u@gmail.com> (https://github.com/withearth)",
-    "Yongseok Kang <feelform@gmail.com> (https://github.com/feelform)"
+    "Yongseok Kang <feelform@gmail.com> (https://github.com/feelform)",
+    "Yongwoo Yu <me@yowu.dev> (https://yowu.dev)"
   ],
   "license": "Apache-2.0",
   "licenses": [

--- a/test/config.test.js
+++ b/test/config.test.js
@@ -42,11 +42,20 @@ test('Should be configured with argument', function (t) {
   t.equal(agentId, conf.agentId)
 })
 
-test('Should be read from config file', function (t) {
+test('Should be read from config *.json file', function (t) {
   t.plan(1)
 
-  const testConfig = require('./pinpoint-config-test')
+  const testConfig = require('./pinpoint-config-test.json')
   const result = config.readConfigJson(testConfig)
   log.debug(result)
   t.ok(result)
 })
+
+test('Should be read from config *.js file', function (t) {
+  t.plan(1)
+
+  const testConfig = require('./pinpoint-config-test.js')
+  const result = config.readConfigJson(testConfig)
+  log.debug(result)
+  t.ok(result)
+});

--- a/test/pinpoint-config-test.js
+++ b/test/pinpoint-config-test.js
@@ -1,0 +1,27 @@
+module.exports = {
+  enable: true,
+  'agent-id': 'node.test.app',
+  'application-name': 'node.test.app',
+  'application-type': 1400,
+  collector: {
+    ip: '127.0.0.1',
+    'span-port': 9993,
+    'stat-port': 9992,
+    'tcp-port': 9991,
+  },
+  sampling: {
+    enable: true,
+    rate: 1,
+  },
+  'http-status-code-errors': ['5xx'],
+  'enabled-stats-monitor-sending': false,
+  'enabled-active-thread-count': false,
+  'log-level': 'DEBUG',
+  modules: {
+    express: true,
+    koa: true,
+    mongodb: true,
+    redis: true,
+  },
+};
+


### PR DESCRIPTION
There are people who want to manage config files such as tsconfig, `pm2`, `webpack`, `eslint`, etc. as `*.js` rather than `*.json` files. And most packages support reading configuration files with the `*.js` extension.

I want to manage the pinpoint-config file with js extension rather than json extension.

This is a PR on the above.