### PR TITLE
fixed Config init processing bug

### DIFF
--- a/lib/config.js
+++ b/lib/config.js
@@ -90,8 +90,8 @@ const init = (initOptions = {}) => {
       readConfigJson(defaultConfig),
       readConfigJson(readRootConfigFile()),
       readFromEnv(),
-      readConfigJson(initOptions))
-
+      initOptions)
+    
   log.init(agentConfig.logLevel)
 
   Object.entries(REQUIRE_CONFIG).forEach(([propertyName, description]) => {


### PR DESCRIPTION
When creating the agentConfig object, it is created by combining `defaultConfig`, `readRootConfigFile`, `envVariable` and `initOption` passed as a parameter of the Agent Constructor. ([config.js:89](https://github.com/pinpoint-apm/pinpoint-node-agent/blob/master/lib/config.js#L89))

`defaultConfig` and `readRootConfigFile` are in json format, but `initOptions` is in pure javascript object format. So nothing is extracted via `readConfigJson()` method.

Looking at [test-express.js:8](https://github.com/pinpoint-apm/pinpoint-node-agent/blob/master/test/test-express.js#L8) in the test code, `initOptions` is not a have depth json type.

Fixed `agentConfig` assign logic, so that it can be properly combined.
Thank you.