### PR TITLE
Fix app crash without callback function in redis instrumentation module

### DIFF
--- a/lib/instrumentation/module/redis.js
+++ b/lib/instrumentation/module/redis.js
@@ -41,7 +41,10 @@ module.exports = function (agent, version, redis) {
   function wrapInternalSendCommand (original) {
     return function wrappedInternalSendCommand (commandObj) {
       const trace = agent.traceContext.currentTraceObject()
-      if (commandObj && commandObj.callback.name != "pinpointCallbackWrapper" && trace) {
+      const isPinpointCallbackWrapper = commandObj &&
+        typeof commandObj.callback === 'function' &&
+        commandObj.callback.name === "pinpointCallbackWrapper"
+      if (!isPinpointCallbackWrapper && trace) {
         const command = commandObj && commandObj.command
         const spanEventRecorder = trace.traceBlockBegin()
         spanEventRecorder.recordServiceType(ServiceTypeCode.redis)


### PR DESCRIPTION
`
const connection = redis.createClient({
    host: opt.url,
    db: opt.db
})
`
db select command is executed without a callback function in redis pakcage.

`commandObj.callback.name`
In the above code if there is no callback function
Cannot read property 'name' of undefined error occurs
so I modified the code.