### PR TITLE
[#285] Client Side gRPC Stream deadline retry refactoring

### DIFF
--- a/lib/client/grpc-data-sender.js
+++ b/lib/client/grpc-data-sender.js
@@ -25,6 +25,7 @@ const activeRequestRepository = require('../metric/active-request-repository')
 const { setInterval } = require('node:timers/promises')
 const DeadlineOptionsBuilder = require('./deadline-options-builder')
 const { logError } = require('./grpc-errors')
+const StreamDeadlineOptionsBuilder = require('./stream-deadline-options-builder')
 
 // AgentInfoSender.java
 // refresh daily
@@ -39,17 +40,16 @@ class GrpcDataSender {
     this.collectorStatPort = collectorStatPort
     this.collectorSpanPort = collectorSpanPort
 
+    this.unaryDeadlineOptionsBuilder = new DeadlineOptionsBuilder()
     this.initializeClients()
     this.initializeMetadataClients()
-    this.initializeSpanStream(collectorIp, collectorSpanPort, config)
-    this.initializeStatStream(collectorIp, collectorStatPort, config)
     this.initializePingStream()
     this.initializeAgentInfoScheduler()
     this.initializeProfilerClients(collectorIp, collectorTcpPort, config)
 
-    this.commandEchoDeadlineOptionsBuilder = new DeadlineOptionsBuilder()
-    this.agentInfoOptionsBuilder = new DeadlineOptionsBuilder()
-    this.metadataOptionsBuilder = new DeadlineOptionsBuilder()
+    this.clientSideStreamDeadlineOptionsBuilder = new StreamDeadlineOptionsBuilder(config)
+    this.initializeSpanStream(collectorIp, collectorSpanPort, config)
+    this.initializeStatStream(collectorIp, collectorStatPort, config)
   }
 
   close() {
@@ -158,7 +158,7 @@ class GrpcDataSender {
 
   sendAgentInfo(agentInfo, callback) {
     const pAgentInfo = dataConvertor.convertAgentInfo(agentInfo)
-    let options = this.agentInfoOptionsBuilder.build()
+    let options = this.unaryDeadlineOptionsBuilder.build()
     this.agentClient.requestAgentInfo(pAgentInfo, options, (err, response) => {
       logError('sendAgentInfo err: ', err)
       if (typeof callback === 'function') {
@@ -169,7 +169,7 @@ class GrpcDataSender {
     this.closeScheduler()
     if (this.agentInfoDailyScheduler) {
       this.removeJobForAgentInfo = this.agentInfoDailyScheduler.addJob(() => {
-        options = this.agentInfoOptionsBuilder.build()
+        options = this.unaryDeadlineOptionsBuilder.build()
         this.agentClient.requestAgentInfo(pAgentInfo, options, (err, response) => {
           logError('sendAgentInfo err: ', err)
           if (typeof callback === 'function') {
@@ -183,7 +183,7 @@ class GrpcDataSender {
 
   sendApiMetaInfo(apiMetaInfo, callback) {
     const pApiMetaData = dataConvertor.convertApiMetaInfo(apiMetaInfo)
-    const options = this.metadataOptionsBuilder.build()
+    const options = this.unaryDeadlineOptionsBuilder.build()
     this.metadataClient.requestApiMetaData(pApiMetaData, options, (err, response) => {
       logError(err)
       if (callback) {
@@ -194,7 +194,7 @@ class GrpcDataSender {
 
   sendStringMetaInfo(stringMetaInfo, callback) {
     const pStringMetaData = dataConvertor.convertStringMetaInfo(stringMetaInfo)
-    const options = this.metadataOptionsBuilder.build()
+    const options = this.unaryDeadlineOptionsBuilder.build()
     this.metadataClient.requestStringMetaData(pStringMetaData, options, (err, response) => {
       logError(err)
       if (callback) {
@@ -205,7 +205,7 @@ class GrpcDataSender {
 
   sendSqlMetaInfo(sqlMetaData, callback) {
     const pSqlMetaData = sqlMetaData.valueOfProtocolBuffer()
-    const options = this.metadataOptionsBuilder.build()
+    const options = this.unaryDeadlineOptionsBuilder.build()
     this.metadataClient.requestSqlMetaData(pSqlMetaData, options, (err, response) => {
       logError(err)
       if (callback) {
@@ -216,7 +216,7 @@ class GrpcDataSender {
 
   sendSqlUidMetaData(sqlMetaData, callback) {
     const pSqlMetaData = sqlMetaData.valueOfProtocolBuffer()
-    const options = this.metadataOptionsBuilder.build()
+    const options = this.unaryDeadlineOptionsBuilder.build()
     this.metadataClient.requestSqlUidMetaData(pSqlMetaData, options, (err, response) => {
       logError(err)
       if (callback) {
@@ -349,7 +349,7 @@ class GrpcDataSender {
   }
 
   sendCommandEcho(commandEchoResponse, callback) {
-    let options = this.commandEchoDeadlineOptionsBuilder.build()
+    let options = this.unaryDeadlineOptionsBuilder.build()
     this.profilerClient.commandEcho(commandEchoResponse, options, (err, response) => {
       if (err) {
         log.error(err)

--- a/lib/client/stream-deadline-options-builder.js
+++ b/lib/client/stream-deadline-options-builder.js
@@ -1,0 +1,19 @@
+/**
+ * Pinpoint Node.js Agent
+ * Copyright 2020-present NAVER Corp.
+ * Apache License v2.0
+ */
+
+'use strict'
+
+const DeadlineOptionsBuilder = require('./deadline-options-builder')
+
+const defaultSeconds = 10 * 60 // 10 minutes
+class StreamDeadlineOptionsBuilder extends DeadlineOptionsBuilder {
+    constructor(config) {
+        const seconds = isNaN(config?.streamDeadlineMinutesClientSide) ? defaultSeconds : config.streamDeadlineMinutesClientSide * 60
+        super(seconds)
+    }
+}
+
+module.exports = StreamDeadlineOptionsBuilder

--- a/test/client/grpc-stream-deadline.test.js
+++ b/test/client/grpc-stream-deadline.test.js
@@ -176,7 +176,7 @@ test('sendAgentInfo deadline and metadata', (t) => {
 
                 t.end()
             }
-            grpcDataSender.agentInfoOptionsBuilder.setSeconds(0.1)
+            grpcDataSender.unaryDeadlineOptionsBuilder.setSeconds(0.1)
 
             grpcDataSender.sendAgentInfo({
                 hostname: 'hostname',
@@ -227,7 +227,7 @@ test('sendAgentInfo deadline and no agent name metadata', (t) => {
         })
 
         function deadlineFunctionalTest() {
-            grpcDataSender.agentInfoOptionsBuilder.setSeconds(0.1)
+            grpcDataSender.unaryDeadlineOptionsBuilder.setSeconds(0.1)
 
             const callback = (err, response) => {
                 t.false(response, '2st sendAgentInfo response is undefined')
@@ -287,7 +287,7 @@ test('sendApiMetaInfo deadline', (t) => {
         })
 
         function apiMetaInfoFunctionalTest() {
-            grpcDataSender.metadataOptionsBuilder.setSeconds(0.1)
+            grpcDataSender.unaryDeadlineOptionsBuilder.setSeconds(0.1)
             grpcDataSender.sendApiMetaInfo({
                 hostname: 'hostname',
                 "serviceType": 1400,
@@ -342,7 +342,7 @@ test('sendStringMetaInfo deadline', (t) => {
         })
 
         function stringMetaInfoFunctionalTest() {
-            grpcDataSender.metadataOptionsBuilder.setSeconds(0.1)
+            grpcDataSender.unaryDeadlineOptionsBuilder.setSeconds(0.1)
             grpcDataSender.sendStringMetaInfo({
                 hostname: 'hostname',
                 "serviceType": 1400,

--- a/test/client/stream-deadline-options-builder.test.js
+++ b/test/client/stream-deadline-options-builder.test.js
@@ -1,0 +1,30 @@
+/**
+ * Pinpoint Node.js Agent
+ * Copyright 2021-present NAVER Corp.
+ * Apache License v2.0
+ */
+
+'use strict'
+
+const test = require('tape')
+const agent = require('../support/agent-singleton-mock')
+const StreamDeadlineOptionsBuilder = require('../../lib/client/stream-deadline-options-builder')
+
+test('stream deadline options from config without exceptions', function (t) {
+    agent.bindHttp({ 'stream-deadline-minutes': null })
+    let dut = new StreamDeadlineOptionsBuilder(agent.config)
+    t.equal(dut.deadlineSeconds, 0, 'If stream deadline seconds JSON is null, Node.js runtime is returned as 0')
+
+    agent.bindHttp({ 'stream-deadline-minutes': undefined })
+    dut = new StreamDeadlineOptionsBuilder(agent.config)
+    t.equal(dut.deadlineSeconds, 600, 'If stream deadline seconds JSON is undefined, returns default 600 seconds')
+
+    agent.bindHttp({ 'stream-deadline-minutes': { 'client-side': 1 }})
+    dut = new StreamDeadlineOptionsBuilder(agent.config)
+    t.equal(dut.deadlineSeconds, 60, 'If stream deadline seconds JSON is 1, returns 60 seconds')
+
+    agent.bindHttp()
+    dut = new StreamDeadlineOptionsBuilder(agent.config)
+    t.equal(dut.deadlineSeconds, 600, 'If stream deadline seconds JSON is not set, returns default 600 seconds')
+    t.end()
+})


### PR DESCRIPTION
- [ ] The stream deadline configuration is loaded from pinpoint-config-default.json
- [ ] Any value (null, undefined) should not terminate the agent because it needs to load JSON data and perform arithmetic.