### PR TITLE
[#428] Add URI stats bucketing and end-time aware aggregation

### DIFF
--- a/lib/metric/snapshot-manager.js
+++ b/lib/metric/snapshot-manager.js
@@ -1,0 +1,42 @@
+/**
+ * Pinpoint Node.js Agent
+ * Copyright 2020-present NAVER Corp.
+ * Apache License v2.0
+ */
+
+'use strict'
+
+class SnapshotManager {
+    constructor(snapshotFactory, timestampExtractor) {
+        this.snapshotFactory = snapshotFactory
+        this.timestampExtractor = timestampExtractor
+        this.current = null
+    }
+
+    getCurrent(timestamp) {
+        if (!this.current) {
+            this.current = this.snapshotFactory(timestamp)
+        }
+        return this.current
+    }
+
+    takeSnapshot(timestamp) {
+        if (!this.current) {
+            return null
+        }
+
+        const currentTimestamp = this.timestampExtractor(this.current)
+
+        if (timestamp <= currentTimestamp) {
+            return null
+        }
+
+        const completedSnapshot = this.current
+        this.current = null
+        return completedSnapshot
+    }
+}
+
+module.exports = {
+    SnapshotManager
+}

--- a/lib/metric/uri-stats-info-builder.js
+++ b/lib/metric/uri-stats-info-builder.js
@@ -15,6 +15,18 @@ class UriStatsInfo {
         this.traceStartTime = traceStartTime
         this.traceEndTime = traceEndTime
     }
+
+    getUri() {
+        return this.uri
+    }
+
+    getElapsed() {
+        return this.traceEndTime - this.traceStartTime
+    }
+
+    isFailed() {
+        return this.responseOk !== true
+    }
 }
 
 class UriStatsInfoBuilder {
@@ -35,8 +47,8 @@ class UriStatsInfoBuilder {
         return this
     }
 
-    setErrorCode(errorCode) {
-        this.responseOk = errorCode === 0
+    errorResponse() {
+        this.responseOk = false
         return this
     }
 

--- a/lib/metric/uri-stats-repository.js
+++ b/lib/metric/uri-stats-repository.js
@@ -7,8 +7,37 @@
 'use strict'
 
 const { UriStatsInfoBuilder } = require('./uri-stats-info-builder')
+const { SnapshotManager } = require('./snapshot-manager')
+const { UriStatsSnapshot } = require('./uri-stats-snapshot')
+const DateNow = require('../support/date-now')
+
+// Default maximum number of distinct URIs tracked per snapshot.
+// 1024 is a power of two, providing a reasonable balance between memory usage
+// and the need to cover typical production URI cardinality without tuning.
+const defaultCapacity = 1024
+
+// Default aggregation window for URI statistics in milliseconds.
+// 30 seconds is a common metrics collection interval that smooths short spikes
+// while still providing timely visibility into URI performance.
+const defaultTimeWindow = 30000
+
+// Maximum number of completed snapshots to retain in memory.
+// With a 30-second window, 4 snapshots keep roughly the last 2 minutes of data
+// while keeping memory bounded and polling latency low.
+const snapshotLimit = 4
 
 class UriStatsRepository {
+    constructor(capacity = defaultCapacity, timeWindow = defaultTimeWindow, config) {
+        this.capacity = capacity
+        this.timeWindow = timeWindow
+        this.completedSnapshotQueue = []
+        this.snapshotManager = new SnapshotManager(
+            (baseTimestamp) => new UriStatsSnapshot(baseTimestamp, this.capacity),
+            (snapshot) => snapshot.getBaseTimestamp()
+        )
+        this.config = config
+    }
+
     storeUriStats(spanBuilder, traceEndTime) {
         const uriTemplate = spanBuilder.getUriTemplate()
         if (!uriTemplate) {
@@ -17,11 +46,56 @@ class UriStatsRepository {
 
         const traceRoot = spanBuilder.getTraceRoot()
         const traceStartTime = traceRoot.getTraceStartTime()
-        const uriStatsInfoBuilder = new UriStatsInfoBuilder(uriTemplate, traceStartTime, traceEndTime)
+
+        const builder = new UriStatsInfoBuilder(uriTemplate, traceStartTime, traceEndTime)
         const httpMethod = spanBuilder.getHttpMethod()
         if (httpMethod) {
-            uriStatsInfoBuilder.setMethod(httpMethod)
+            builder.setMethod(httpMethod)
         }
+
+        if (traceRoot.hasErrorCode()) {
+            builder.errorResponse()
+        }
+        builder.setConfig(this.config)
+
+        this.store(builder.build())
+    }
+
+    store(uriStatsInfo) {
+        if (!uriStatsInfo) {
+            return
+        }
+
+        const baseTimestamp = this.calculateBaseTimestamp(DateNow.now())
+
+        this.checkAndFlushSnapshot(baseTimestamp)
+
+        const snapshot = this.snapshotManager.getCurrent(baseTimestamp)
+        snapshot.add(uriStatsInfo)
+    }
+
+    calculateBaseTimestamp(timestamp) {
+        return Math.floor(timestamp / this.timeWindow) * this.timeWindow
+    }
+
+    checkAndFlushSnapshot(timestamp) {
+        const completedSnapshot = this.snapshotManager.takeSnapshot(timestamp)
+        if (completedSnapshot) {
+            this.addCompletedSnapshot(completedSnapshot)
+        }
+    }
+
+    addCompletedSnapshot(snapshot) {
+        if (this.completedSnapshotQueue.length >= snapshotLimit) {
+            this.completedSnapshotQueue.shift()
+        }
+        this.completedSnapshotQueue.push(snapshot)
+    }
+
+    poll() {
+        const baseTimestamp = this.calculateBaseTimestamp(DateNow.now())
+        this.checkAndFlushSnapshot(baseTimestamp)
+        return this.completedSnapshotQueue.shift()
     }
 }
 
@@ -43,7 +117,7 @@ class UriStatsRepositoryBuilder {
             return UriStatsRepositoryBuilder.nullObject
         }
 
-        return new UriStatsRepository()
+        return new UriStatsRepository(defaultCapacity, defaultTimeWindow, this.config)
     }
 }
 

--- a/lib/metric/uri-stats-snapshot.js
+++ b/lib/metric/uri-stats-snapshot.js
@@ -1,0 +1,88 @@
+/**
+ * Pinpoint Node.js Agent
+ * Copyright 2020-present NAVER Corp.
+ * Apache License v2.0
+ */
+
+'use strict'
+
+class UriStatsSnapshot {
+    constructor(baseTimestamp, capacity) {
+        this.baseTimestamp = baseTimestamp
+        this.capacity = capacity
+        this.dataMap/*<String, UriStatsEntry>*/ = new Map()
+    }
+
+    add(uriStatsInfo) {
+        const uri = uriStatsInfo.getUri()
+
+        if (this.dataMap.size >= this.capacity && !this.dataMap.has(uri)) {
+            return false
+        }
+
+        let entry = this.dataMap.get(uri)
+        if (!entry) {
+            entry = new UriStatsEntry(uri)
+            this.dataMap.set(uri, entry)
+        }
+        entry.add(uriStatsInfo)
+        return true
+    }
+
+    getBaseTimestamp() {
+        return this.baseTimestamp
+    }
+}
+
+class UriStatsEntry {
+    constructor(uri) {
+        this.uri = uri
+        this.totalHistogram = createHistogram()
+        this.failedHistogram = createHistogram()
+    }
+
+    add(info) {
+        const elapsed = info.getElapsed()
+
+        updateHistogram(this.totalHistogram, elapsed)
+
+        if (info.isFailed()) {
+            updateHistogram(this.failedHistogram, elapsed)
+        }
+    }
+}
+
+function createHistogram() {
+    return {
+        count: 0,
+        sum: 0,
+        max: 0,
+        buckets: [0, 0, 0, 0, 0, 0, 0, 0]
+    }
+}
+
+function updateHistogram(histogram, elapsed) {
+    histogram.count += 1
+    histogram.sum += elapsed
+    if (elapsed > histogram.max) {
+        histogram.max = elapsed
+    }
+
+    const idx = getBucketIndex(elapsed)
+    histogram.buckets[idx] += 1
+}
+
+function getBucketIndex(elapsed) {
+    if (elapsed < 100) return 0
+    if (elapsed < 300) return 1
+    if (elapsed < 500) return 2
+    if (elapsed < 1000) return 3
+    if (elapsed < 3000) return 4
+    if (elapsed < 5000) return 5
+    if (elapsed < 8000) return 6
+    return 7
+}
+
+module.exports = {
+    UriStatsSnapshot
+}

--- a/lib/support/date-now.js
+++ b/lib/support/date-now.js
@@ -1,0 +1,25 @@
+/**
+ * Pinpoint Node.js Agent
+ * Copyright 2020-present NAVER Corp.
+ * Apache License v2.0
+ */
+
+'use strict'
+
+class DateNow {
+    static offset = 0
+
+    static now() {
+        return Date.now() + DateNow.offset
+    }
+
+    static setOffset(ms) {
+        DateNow.offset = ms
+    }
+
+    static reset() {
+        DateNow.offset = 0
+    }
+}
+
+module.exports = DateNow

--- a/test/metric/uri-stats-repository.test.js
+++ b/test/metric/uri-stats-repository.test.js
@@ -1,0 +1,111 @@
+const test = require('tape')
+const { UriStatsRepository } = require('../../lib/metric/uri-stats-repository')
+const { UriStatsInfo } = require('../../lib/metric/uri-stats-info-builder')
+const DateNow = require('../../lib/support/date-now')
+
+test('UriStatsRepository should store and rotate snapshots using DateNow', (t) => {
+    // config mock
+    const config = { isUriStatsEnabled: () => true }
+    // 30s interval
+    const repository = new UriStatsRepository(10, 30000, config)
+
+    // Reset Time
+    DateNow.setOffset(0)
+    const now = DateNow.now()
+    const baseTimestamp = repository.calculateBaseTimestamp(now)
+
+    // 1. Store first data
+    const info1 = new UriStatsInfo('/api/v1', true, now, now + 50)
+    repository.store(info1)
+
+    const currentSnapshot = repository.snapshotManager.getCurrent(baseTimestamp)
+    t.ok(currentSnapshot, 'Current snapshot should exist')
+    t.equal(currentSnapshot.dataMap.get('/api/v1').totalHistogram.count, 1, 'Should count 1 request')
+
+    // 2. Advance time by 31 seconds to force rotation
+    // (Current bucket base + 30000 < New time)
+    DateNow.setOffset(31000)
+
+    const later = DateNow.now()
+    const info2 = new UriStatsInfo('/api/v1', true, later, later + 200)
+
+    repository.store(info2)
+
+    // Previous snapshot should be in queue
+    t.equal(repository.completedSnapshotQueue.length, 1, 'Should have 1 completed snapshot in queue')
+
+    // Check new snapshot
+    const newBaseTimestamp = repository.calculateBaseTimestamp(later)
+    const newSnapshot = repository.snapshotManager.getCurrent(newBaseTimestamp)
+    t.ok(newSnapshot.dataMap.get('/api/v1'), 'New snapshot should have api/v1')
+
+    // 3. Poll completed snapshot
+    const completed = repository.poll()
+    t.ok(completed, 'Should poll a snapshot')
+    t.equal(completed.dataMap.get('/api/v1').totalHistogram.count, 1, 'Completed snapshot has correct data')
+
+    // Reset offset for other tests
+    DateNow.setOffset(0)
+    t.end()
+})
+
+test('UriStatsSnapshot histogram logic', (t) => {
+    const config = { isUriStatsEnabled: () => true }
+    const repository = new UriStatsRepository(1000, 30000, config)
+    DateNow.setOffset(0)
+
+    const uri = '/histogram-test'
+    // Success cases
+    repository.store(new UriStatsInfo(uri, true, 0, 50))   // Bucket 0
+    repository.store(new UriStatsInfo(uri, true, 0, 150))  // Bucket 1
+    repository.store(new UriStatsInfo(uri, true, 0, 9000)) // Bucket 7
+
+    // Failed case
+    repository.store(new UriStatsInfo(uri, false, 0, 400)) // Bucket 2, Failed
+
+    const baseTimestamp = repository.calculateBaseTimestamp(DateNow.now())
+    const snapshot = repository.snapshotManager.getCurrent(baseTimestamp)
+    const entry = snapshot.dataMap.get(uri)
+
+    t.equal(entry.totalHistogram.count, 4, 'Total count 4')
+    t.equal(entry.totalHistogram.sum, 50 + 150 + 9000 + 400, 'Total sum correct')
+    t.equal(entry.totalHistogram.max, 9000, 'Max elapsed correct')
+
+    // Check Buckets
+    t.equal(entry.totalHistogram.buckets[0], 1, 'Bucket[0] count 1')
+    t.equal(entry.totalHistogram.buckets[1], 1, 'Bucket[1] count 1')
+    t.equal(entry.totalHistogram.buckets[2], 1, 'Bucket[2] count 1')
+    t.equal(entry.totalHistogram.buckets[7], 1, 'Bucket[7] count 1')
+
+    // Check Failed Histogram
+    t.equal(entry.failedHistogram.count, 1, 'Failed count 1')
+    t.equal(entry.failedHistogram.buckets[2], 1, 'Failed Bucket[2] count 1')
+
+    t.end()
+})
+
+test('UriStatsRepository should limit capacity', (t) => {
+    const config = { isUriStatsEnabled: () => true }
+    const capacity = 2
+    const repository = new UriStatsRepository(capacity, 30000, config)
+    DateNow.setOffset(0)
+
+    repository.store(new UriStatsInfo('/1', true, 0, 10))
+    repository.store(new UriStatsInfo('/2', true, 0, 10))
+    repository.store(new UriStatsInfo('/3', true, 0, 10)) // Should receive false internally or be ignored
+
+    const baseTimestamp = repository.calculateBaseTimestamp(DateNow.now())
+    const snapshot = repository.snapshotManager.getCurrent(baseTimestamp)
+
+    t.equal(snapshot.dataMap.size, 2, 'Should not exceed capacity 2')
+    t.ok(snapshot.dataMap.has('/1'))
+    t.ok(snapshot.dataMap.has('/2'))
+    t.notOk(snapshot.dataMap.has('/3'))
+
+    t.end()
+})
+
+test.onFinish(() => {
+    DateNow.setOffset(0)
+})
+

--- a/test/support/agent-singleton-mock.js
+++ b/test/support/agent-singleton-mock.js
@@ -20,6 +20,7 @@ const GrpcDataSender = require('../../lib/client/grpc-data-sender')
 const { AgentBuilder } = require('../../lib/agent-builder')
 const AgentInfo = require('../../lib/data/dto/agent-info')
 const { ConfigBuilder } = require('../../lib/config-builder')
+const { initializeStats } = require('../../lib/context/uri-stats')
 
 let traces = []
 const resetTraces = () => {
@@ -92,6 +93,9 @@ const agentBuilder = new AgentBuilder(agentInfo)
     .setDataSender(dataSenderMock(config, agentInfo))
     .disablePingScheduler()
     .disableStatsScheduler()
+    .addService(() => {
+        initializeStats(config)
+    })
 const agent = agentBuilder.build()
 
 class MockAgent {


### PR DESCRIPTION
This PR implements URI statistics bucketing with time-windowed aggregation to track HTTP request performance metrics. The changes introduce a histogram-based approach with 8 latency buckets to aggregate total and failed request statistics per URI within 30-second time windows.

