### PR TITLE
[#459] Fix Error Analysis failure count not tracked in DisableTrace path

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,3 +62,11 @@ The package exposes named exports for programmatic use:
 Tests use **Tape** (not Jest/Mocha). Integration tests in `test/instrumentation/module/` use **testcontainers** to spin up real databases (MongoDB, MySQL, PostgreSQL, Redis). The `.testignore` file excludes `node_modules`.
 
 TypeScript declarations are in `index.d.ts` and per-module `.d.ts` files; generated output goes to `dist/`.
+
+## Git Rules
+
+- **One commit per PR**: Before committing, squash all changes into a single commit using `git commit` (not amend). If multiple commits exist on the branch, squash them before pushing.
+- **Commit message format**: `[#ISSUE_NUMBER] Short description` followed by a concise body explaining what and why.
+- **No Co-Authored-By lines**: Do not append `Co-Authored-By` trailers to commit messages.
+- **Testing**: New features and bug fixes must include functional tests for all supported web frameworks (Express, Koa, Next.js). Run relevant test files and confirm they pass before committing.
+- **PR descriptions**: Write in English, keep concise with bullet points, and update via `gh pr edit` when pushing changes that alter scope.

--- a/lib/context/disable-span-event-recorder.js
+++ b/lib/context/disable-span-event-recorder.js
@@ -9,61 +9,77 @@
 const disableAsyncId = require('./trace/disable-async-id')
 
 class DisableSpanEventRecorder {
-  constructor() {
-    this.nextAsyncId = null
-    this.ended = false
-    this.error = null
+  constructor(traceRoot) {
+    this.traceRoot = traceRoot
   }
 
-  recordStartTime() {
-  }
+  recordServiceType() {}
 
-  recordServiceType() {
-  }
+  recordApiDesc() {}
 
-  recordDestinationId() {
-  }
+  recordAttribute() {}
 
-  recordEndPoint() {
-  }
+  recordApiId() {}
 
-  recordNextSpanId() {
-  }
-
-  recordNextAsyncId() {
-  }
-
-  recordApiId() {
-  }
-
-  recordApi() {
-  }
-
-  recordApiWithParameters() {
-  }
-
-  recordApiDesc() {
-  }
-
-  recordApiArguments() {
-  }
-
-  recordAttribute() {
-  }
-
-  recordException() {
-  }
-
-  recordSqlInfo() {
-  }
-
-  recordEnd() {
-    this.ended = true
-  }
+  setApiId0() {}
 
   getNextAsyncId() {
     return disableAsyncId
   }
+
+  recordNextSpanId() {}
+
+  recordDestinationId() {}
+
+  recordApi() {}
+
+  recordArgs() {}
+
+  recordEndPoint() {}
+
+  recordException(error, markError) {
+    if (markError && error) {
+      this.traceRoot.getShared().maskErrorCode(1)
+    }
+  }
+
+  recordSqlInfo() {}
+
+  recordSqlParsingResult() {}
 }
+
+class NullDisableSpanEventRecorder {
+  getNextAsyncId() {
+    return disableAsyncId
+  }
+
+  recordServiceType() {}
+
+  recordApiDesc() {}
+
+  recordAttribute() {}
+
+  recordApiId() {}
+
+  setApiId0() {}
+
+  recordNextSpanId() {}
+
+  recordDestinationId() {}
+
+  recordApi() {}
+
+  recordArgs() {}
+
+  recordEndPoint() {}
+
+  recordException() {}
+
+  recordSqlInfo() {}
+
+  recordSqlParsingResult() {}
+}
+
+DisableSpanEventRecorder.nullObject = new NullDisableSpanEventRecorder()
 
 module.exports = DisableSpanEventRecorder

--- a/lib/context/disable-span-recorder.js
+++ b/lib/context/disable-span-recorder.js
@@ -6,7 +6,52 @@
 
 'use strict'
 
+const annotationKey = require('../constant/annotation-key')
+const { enricherNullObject } = require('../metric/uri/span-recorder-enricher')
+
 class DisableSpanRecorder {
+    constructor(traceRoot, config) {
+        this.traceRoot = traceRoot
+        this.httpStatusCodeErrors = config.getHttpStatusCodeErrors()
+        this.enricher = enricherNullObject
+    }
+
+    recordServiceType() {}
+
+    recordApiId() {}
+
+    recordApi() {}
+
+    setApiId0() {}
+
+    recordAttribute(key, value) {
+        if (key === annotationKey.HTTP_STATUS_CODE && this.httpStatusCodeErrors.isErrorCode(value)) {
+            this.traceRoot.getShared().maskErrorCode(1)
+        }
+    }
+
+    recordRpc() {}
+
+    recordEndPoint() {}
+
+    recordRemoteAddress() {}
+
+    recordException(error, markError = true) {
+        if (markError && error) {
+            this.traceRoot.getShared().maskErrorCode(1)
+        }
+    }
+
+    recordAcceptorHost() {}
+
+    recordParentApplication() {}
+
+    recordEnricher(moduleName, ...args) {
+        this.enricher.record(moduleName, ...args)
+    }
+}
+
+class NullDisableSpanRecorder {
     constructor() {
         this.enricher = enricherNullObject
     }
@@ -38,10 +83,6 @@ class DisableSpanRecorder {
     }
 }
 
-const enricherNullObject = Object.freeze({
-    record() {
-
-    }
-})
+DisableSpanRecorder.nullObject = new NullDisableSpanRecorder()
 
 module.exports = DisableSpanRecorder

--- a/lib/context/disable-trace.js
+++ b/lib/context/disable-trace.js
@@ -13,7 +13,7 @@ class DisableTrace {
     constructor(traceRoot, spanRecorder) {
         this.traceRoot = traceRoot
         this.spanRecorder = spanRecorder
-        this.spanEventRecorder = new DisableSpanEventRecorder()
+        this.spanEventRecorder = new DisableSpanEventRecorder(traceRoot)
     }
 
     traceBlockBegin() {

--- a/lib/context/trace-context.js
+++ b/lib/context/trace-context.js
@@ -75,7 +75,7 @@ class TraceContext {
 
   newLocalTrace(traceRoot) {
     activeRequestRepository.register(traceRoot)
-    const spanRecorder = new DisableSpanRecorder()
+    const spanRecorder = new DisableSpanRecorder(traceRoot, this.config)
     if (this.spanRecorderEnricher) {
       spanRecorder.enricher = this.spanRecorderEnricher
     }

--- a/lib/context/trace/disable-child-trace.js
+++ b/lib/context/trace/disable-child-trace.js
@@ -12,8 +12,8 @@ const DisableSpanRecorder = require('../disable-span-recorder')
 class DisableChildTrace {
   constructor(traceRoot) {
     this.traceRoot = traceRoot
-    this.spanRecorder = new DisableSpanRecorder()
-    this.spanEventRecorder = new DisableSpanEventRecorder()
+    this.spanRecorder = DisableSpanRecorder.nullObject
+    this.spanEventRecorder = DisableSpanEventRecorder.nullObject
   }
 
   traceBlockBegin() {

--- a/lib/context/trace/span-recorder.js
+++ b/lib/context/trace/span-recorder.js
@@ -8,6 +8,7 @@
 
 const annotationKey = require('../../constant/annotation-key')
 const Annotations = require('../../instrumentation/context/annotation/annotations')
+const { enricherNullObject } = require('../../metric/uri/span-recorder-enricher')
 
 class SpanRecorder {
     constructor(spanBuilder, config) {
@@ -106,11 +107,5 @@ class SpanRecorder {
         this.enricher.record(moduleName, ...args)
     }
 }
-
-const enricherNullObject = Object.freeze({
-    record() {
-
-    }
-})
 
 module.exports = SpanRecorder

--- a/lib/metric/uri/span-recorder-enricher.js
+++ b/lib/metric/uri/span-recorder-enricher.js
@@ -54,6 +54,13 @@ class SpanRecorderEnricher {
     }
 }
 
+const enricherNullObject = Object.freeze({
+    record() {
+
+    }
+})
+
 module.exports = {
-    SpanRecorderEnricher
+    SpanRecorderEnricher,
+    enricherNullObject
 }

--- a/test/instrumentation/module/express.test.js
+++ b/test/instrumentation/module/express.test.js
@@ -1692,6 +1692,77 @@ test('Express: Should record request with custom uri template when configured', 
   })
 })
 
+test('Should count failure in URI stats for DisableTrace in Express', function (t) {
+  agent.bindHttp({
+    sampling: { enable: false },
+    features: {
+      uriStats: {
+        httpMethod: false,
+        capacity: 1000
+      }
+    }
+  })
+
+  const { UriStatsRepository } = require('../../../lib/metric/uri/uri-stats-repository')
+  const DateNow = require('../../../lib/support/date-now')
+
+  const PATH = '/integration/uri-stats/disable-trace-failure'
+  const app = new express()
+  let resolveTraceClosed
+  const traceClosed = new Promise((resolve) => {
+    resolveTraceClosed = resolve
+  })
+
+  app.get(PATH, function (req, res, next) {
+    agent.callbackTraceClose(() => {
+      setImmediate(() => {
+        const repository = getUriStatsRepository()
+
+        t.ok(repository instanceof UriStatsRepository, 'Repository is initialized')
+
+        const now = DateNow.now()
+        const timeWindow = 30000
+        const baseTimestamp = Math.floor(now / timeWindow) * timeWindow
+
+        const snapshot = repository.snapshotManager.getCurrent(baseTimestamp)
+        t.ok(snapshot, 'Snapshot exists')
+
+        const expectedKey = PATH
+        const entry = snapshot.dataMap.get(expectedKey)
+
+        t.ok(entry, `Entry for ${expectedKey} exists`)
+        if (entry) {
+          t.equal(entry.totalHistogram.count, 1, 'DisableTrace failure request counted in total histogram')
+          t.equal(entry.failedHistogram.count, 1, 'DisableTrace failure request counted in failed histogram')
+        }
+
+        resolveTraceClosed()
+      })
+    })
+    next(new Error('disable trace failure test'))
+  })
+  app.use(function (err, req, res, next) {
+    res.status(500).send('error')
+  })
+
+  const server = app.listen(TEST_ENV.port, async () => {
+    try {
+      await axios.get(getServerUrl(PATH), {
+        timeout: 3000,
+        validateStatus: () => true,
+        httpAgent: new http.Agent({ keepAlive: false }),
+        httpsAgent: new https.Agent({ keepAlive: false }),
+      })
+      await traceClosed
+    } catch (e) {
+      t.fail(e)
+    } finally {
+      server.close()
+      t.end()
+    }
+  })
+})
+
 test('Express: Should not override uri template from user input when useUserInput is false', function (t) {
   agent.bindHttp({
     features: {

--- a/test/instrumentation/module/koa.test.js
+++ b/test/instrumentation/module/koa.test.js
@@ -416,3 +416,75 @@ test('Should aggregate URI stats for DisableTrace in Koa', function (t) {
     }
   })
 })
+
+test('Should count failure in URI stats for DisableTrace in Koa', function (t) {
+  agent.bindHttp({
+    sampling: { enable: false },
+    features: {
+      uriStats: {
+        httpMethod: false,
+        capacity: 1000
+      }
+    }
+  })
+
+  const { UriStatsRepository } = require('../../../lib/metric/uri/uri-stats-repository')
+  const DateNow = require('../../../lib/support/date-now')
+
+  const PATH = '/integration/uri-stats/disable-trace-failure'
+  const app = new Koa()
+  const router = new Router()
+  let resolveTraceClosed
+  const traceClosed = new Promise((resolve) => {
+    resolveTraceClosed = resolve
+  })
+
+  router.get(PATH, async (ctx) => {
+    agent.callbackTraceClose(() => {
+      setImmediate(() => {
+        const repository = getUriStatsRepository()
+
+        t.ok(repository instanceof UriStatsRepository, 'Repository is initialized')
+
+        const now = DateNow.now()
+        const timeWindow = 30000
+        const baseTimestamp = Math.floor(now / timeWindow) * timeWindow
+
+        const snapshot = repository.snapshotManager.getCurrent(baseTimestamp)
+        t.ok(snapshot, 'Snapshot exists')
+
+        const expectedKey = PATH
+        const entry = snapshot.dataMap.get(expectedKey)
+
+        t.ok(entry, `Entry for ${expectedKey} exists`)
+        if (entry) {
+          t.equal(entry.totalHistogram.count, 1, 'DisableTrace failure request counted in total histogram')
+          t.equal(entry.failedHistogram.count, 1, 'DisableTrace failure request counted in failed histogram')
+        }
+
+        resolveTraceClosed()
+      })
+    })
+    ctx.status = 500
+    ctx.body = 'error'
+  })
+
+  app.use(router.routes()).use(router.allowedMethods())
+
+  const server = app.listen(TEST_ENV.port, async () => {
+    try {
+      await axios.get(getServerUrl(PATH), {
+        timeout: 3000,
+        validateStatus: () => true,
+        httpAgent: new http.Agent({ keepAlive: false }),
+        httpsAgent: new https.Agent({ keepAlive: false }),
+      })
+      await traceClosed
+    } catch (e) {
+      t.fail(e)
+    } finally {
+      server.close()
+      t.end()
+    }
+  })
+})

--- a/test/instrumentation/module/nextjs/next.js.test.js
+++ b/test/instrumentation/module/nextjs/next.js.test.js
@@ -320,8 +320,9 @@ test('fetch /api/custom-uri with pinpoint-sampled:s0 should skip span', async (t
     t.end()
 })
 
-test('fetch /api/error-500', async (t) => {
+test('fetch /api/error-500 should record span error and failure in URI stats', async (t) => {
     receivedSpans = []
+    receivedStats = []
     try {
         const response = await fetch('http://127.0.0.1:3000/api/error-500')
         t.equal(response.status, 500, '/api/error-500 responds with 500')
@@ -342,6 +343,39 @@ test('fetch /api/error-500', async (t) => {
             t.equal(statusCodeAnnotation.getValue().getIntvalue(), 500, 'status code annotation value should be 500')
         }
 
+        await new Promise(resolve => setTimeout(resolve, 3000))
+
+        const mergedStats = {}
+        receivedStats.forEach(statMsg => {
+            const agentUriStat = statMsg.getAgenturistat ? statMsg.getAgenturistat() : null
+            if (agentUriStat) {
+                agentUriStat.getEachuristatList().forEach(each => {
+                    const uri = each.getUri()
+                    if (!mergedStats[uri]) {
+                        mergedStats[uri] = {
+                            totalBuckets: new Array(8).fill(0),
+                            failedBuckets: new Array(8).fill(0)
+                        }
+                    }
+                    const totalHistList = each.getTotalhistogram().getHistogramList()
+                    totalHistList.forEach((count, idx) => mergedStats[uri].totalBuckets[idx] += count)
+
+                    const failedHistList = each.getFailedhistogram().getHistogramList()
+                    failedHistList.forEach((count, idx) => mergedStats[uri].failedBuckets[idx] += count)
+                })
+            }
+        })
+
+        const errorUri = '/user/input/uri/error-500'
+        const stat = mergedStats[errorUri]
+        t.ok(stat, `URI stats found for ${errorUri}`)
+        if (stat) {
+            const totalCount = stat.totalBuckets.reduce((acc, val) => acc + val, 0)
+            t.equal(totalCount, 1, 'Total count should be 1')
+
+            const failedCount = stat.failedBuckets.reduce((acc, val) => acc + val, 0)
+            t.equal(failedCount, 1, 'Failed count should be 1')
+        }
     } catch (err) {
         t.fail(err.message)
     }

--- a/test/instrumentation/module/nextjs/nextjs-app-router/pages/api/error-500.js
+++ b/test/instrumentation/module/nextjs/nextjs-app-router/pages/api/error-500.js
@@ -1,4 +1,5 @@
 const handler = function(req, res) {
+  req['pinpoint.metric.uri-template'] = '/user/input/uri/error-500'
   res.status(500).json({ error: 'Internal Server Error' })
 }
 


### PR DESCRIPTION
## Summary

- Fix `DisableSpanRecorder.recordAttribute()`/`recordException()` being no-ops, causing failures not counted in DisableTrace path
- Introduce nullObject pattern for `DisableSpanRecorder`/`DisableSpanEventRecorder`
- Add missing methods and reorder to match `SpanEventRecorder` interface
- Extract duplicated `enricherNullObject` into `span-recorder-enricher.js`
- `DisableChildTrace` uses nullObject instances (async span chunks, not URI stats target)

## Test plan

- [x] Express 347 tests pass (incl. DisableTrace failure counting)
- [x] Koa 43 tests pass (incl. DisableTrace failure counting)
- [x] Next.js 23 tests pass (incl. error-500 failure URI stats)
- [x] uri-stats-repository 29 unit tests pass

Closes #459