### PR TITLE
[#455] Fix empty className and methodName in exception FrameStack

### DIFF
--- a/lib/context/trace/exception-builder.js
+++ b/lib/context/trace/exception-builder.js
@@ -83,7 +83,7 @@ class ExceptionBuilder {
 
         const exception = new Exception(className, message, Date.now())
         exception.frameStack = stack.slice(1).map(callSite => {
-            const { type, location, lineNumber, functionName, methodName } = namedGroupCallSite(callSite.trim())
+            const { type, location, fileName, lineNumber, functionName, methodName } = namedGroupCallSite(callSite.trim())
 
             let functionNameWithMethod
             if (functionName && methodName) {
@@ -94,7 +94,7 @@ class ExceptionBuilder {
                 functionNameWithMethod = methodName
             }
 
-            return new Frame(type, location, lineNumber, functionNameWithMethod)
+            return new Frame(type || fileName || nullErrorClassName, location, lineNumber, functionNameWithMethod || '<anonymous>')
         })
         exception.stack = stack
         return exception

--- a/test/context/make-method-descriptor-builder.test.js
+++ b/test/context/make-method-descriptor-builder.test.js
@@ -53,7 +53,7 @@ test('express stack: ensure computed method names and file/line are preserved in
     t.equal(exception.frameStack.length, 3)
 
     let frame = exception.frameStack[0]
-    t.equal(frame.className, '', 'className new')
+    t.equal(frame.className, 'loader.js', 'className new: fallback to fileName')
     t.true(frame.fileName.endsWith('internal/modules/cjs/loader.js'), 'fileName new')
     t.equal(frame.methodName, 'FunctionName')
     t.equal(frame.lineNumber, 699)
@@ -65,7 +65,7 @@ test('express stack: ensure computed method names and file/line are preserved in
     t.equal(frame.lineNumber, 699)
 
     frame = exception.frameStack[2]
-    t.equal(frame.className, '', 'className async')
+    t.equal(frame.className, 'loader.js', 'className async: fallback to fileName')
     t.true(frame.fileName.endsWith('internal/modules/cjs/loader.js'), 'fileName async')
     t.equal(frame.methodName, 'FunctionName')
     t.equal(frame.lineNumber, 699)
@@ -92,7 +92,7 @@ test('express stack with promise frame: ensure anonymous Promise frame is parsed
     t.equal(exception.errorMessage, 'express case')
     t.equal(exception.frameStack.length, 12)
 
-    t.equal(promiseFrame.className, '', 'className promise')
+    t.equal(promiseFrame.className, '<anonymous>', 'className promise: fallback to fileName')
     t.equal(promiseFrame.fileName, '<anonymous>')
     t.equal(promiseFrame.methodName, 'Promise')
     t.equal(promiseFrame.lineNumber, 0)

--- a/test/context/trace/exception-builder.test.js
+++ b/test/context/trace/exception-builder.test.js
@@ -100,3 +100,30 @@ test('ExceptionBuilder Test - snapshot-like multiline', (t) => {
         functionName: 'next'
     }, 'at next (/Users/workspace/pinpoint/pinpoint-node-agent/node_modules/express/lib/router/index.js:280:10)')
 })
+
+test('ExceptionBuilder should use fileName as className fallback and <anonymous> as methodName fallback', (t) => {
+    const err = new Error('fallback test')
+    err.stack = `Error: fallback test
+    at /Users/app/index.js:10:5
+    at Layer.handle [as handle_request] (/Users/app/node_modules/express/lib/router/layer.js:95:5)
+    at next (/Users/app/node_modules/express/lib/router/route.js:149:13)`
+
+    const actual = new ExceptionBuilder(err).build()
+
+    // Frame without type and functionName: className=fileName, methodName='<anonymous>'
+    const frame0 = actual.frameStack[0]
+    t.equal(frame0.className, 'index.js', 'className should fallback to fileName when type is undefined')
+    t.equal(frame0.methodName, '<anonymous>', 'methodName should fallback to <anonymous> when functionName is undefined')
+
+    // Frame with type and functionName: no fallback needed
+    const frame1 = actual.frameStack[1]
+    t.equal(frame1.className, 'Layer', 'className should be type when present')
+    t.equal(frame1.methodName, 'handle [as handle_request]', 'methodName should be functionName when present')
+
+    // Frame without type but with functionName: className=fileName, methodName=functionName
+    const frame2 = actual.frameStack[2]
+    t.equal(frame2.className, 'route.js', 'className should fallback to fileName when type is undefined')
+    t.equal(frame2.methodName, 'next', 'methodName should be functionName when present')
+
+    t.end()
+})

--- a/test/instrumentation/module/express.test.js
+++ b/test/instrumentation/module/express.test.js
@@ -306,16 +306,16 @@ function unhandledExceptionStatsFrameTest(trace, t) {
   }
 
   const expectedStackTracePrefix = [
-    '<anonymous> (<workspace>/test/instrumentation/module/express.test.js:<line>)',
+    'express.test.js.<anonymous> (<workspace>/test/instrumentation/module/express.test.js:<line>)',
     'Layer.handle [as handle_request] (<workspace>/node_modules/express/lib/router/layer.js:<line>)',
-    'next (<workspace>/node_modules/express/lib/router/route.js:<line>)',
+    'route.js.next (<workspace>/node_modules/express/lib/router/route.js:<line>)',
     'Route.dispatch (<workspace>/node_modules/express/lib/router/route.js:<line>)',
     'InterceptorRunner.run (<workspace>/lib/instrumentation/interceptor-runner.js:<line>)',
-    'wrapped (<workspace>/lib/instrumentation/module/express/express-layer-interceptor.js:<line>)',
+    'express-layer-interceptor.js.wrapped (<workspace>/lib/instrumentation/module/express/express-layer-interceptor.js:<line>)',
     'Layer.handle [as handle_request] (<workspace>/node_modules/express/lib/router/layer.js:<line>)',
-    '<anonymous> (<workspace>/node_modules/express/lib/router/index.js:<line>)',
+    'index.js.<anonymous> (<workspace>/node_modules/express/lib/router/index.js:<line>)',
     'Function.process_params (<workspace>/node_modules/express/lib/router/index.js:<line>)',
-    'next (<workspace>/node_modules/express/lib/router/index.js:<line>)',
+    'index.js.next (<workspace>/node_modules/express/lib/router/index.js:<line>)',
   ].join('\n')
 
   const actualStackTrace = stackTraceElements
@@ -1347,16 +1347,16 @@ test('Functional Test: requestExceptionMetaData should deliver converted excepti
           .join('\n')
 
         const expectedStackTracePrefix = [
-          '<anonymous> (<workspace>/test/instrumentation/module/express.test.js:<line>)',
+          'express.test.js.<anonymous> (<workspace>/test/instrumentation/module/express.test.js:<line>)',
           'Layer.handle [as handle_request] (<workspace>/node_modules/express/lib/router/layer.js:<line>)',
-          'next (<workspace>/node_modules/express/lib/router/route.js:<line>)',
+          'route.js.next (<workspace>/node_modules/express/lib/router/route.js:<line>)',
           'Route.dispatch (<workspace>/node_modules/express/lib/router/route.js:<line>)',
           'InterceptorRunner.run (<workspace>/lib/instrumentation/interceptor-runner.js:<line>)',
-          'wrapped (<workspace>/lib/instrumentation/module/express/express-layer-interceptor.js:<line>)',
+          'express-layer-interceptor.js.wrapped (<workspace>/lib/instrumentation/module/express/express-layer-interceptor.js:<line>)',
           'Layer.handle [as handle_request] (<workspace>/node_modules/express/lib/router/layer.js:<line>)',
-          '<anonymous> (<workspace>/node_modules/express/lib/router/index.js:<line>)',
+          'index.js.<anonymous> (<workspace>/node_modules/express/lib/router/index.js:<line>)',
           'Function.process_params (<workspace>/node_modules/express/lib/router/index.js:<line>)',
-          'next (<workspace>/node_modules/express/lib/router/index.js:<line>)',
+          'index.js.next (<workspace>/node_modules/express/lib/router/index.js:<line>)',
         ].join('\n')
 
         const escapeRegExp = (value) => value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')


### PR DESCRIPTION
## Summary

- Use `fileName` as `className` fallback when type is undefined (JS has no class concept)
- Use `<anonymous>` as `methodName` fallback (consistent with V8 engine convention)
- Server rejects empty strings via `StringPrecondition.requireHasLength()`, causing FrameStack not to be displayed

## Test plan

- [x] exception-builder 19 tests pass (incl. new fallback validation test)

Closes #455