### PR TITLE
[#457] Set uriTemplate in ExceptionMetaData from enricher

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -69,5 +69,5 @@ TypeScript declarations are in `index.d.ts` and per-module `.d.ts` files; genera
 - **Commit message format**: `[#ISSUE_NUMBER] Short description` followed by a concise body explaining what and why.
 - **No Co-Authored-By lines**: Do not append `Co-Authored-By` trailers to commit messages.
 - **Testing**: New features and bug fixes must include functional tests for all supported web frameworks (Express, Koa, Next.js). Run relevant test files and confirm they pass before committing.
-- **PR descriptions**: Write in English, keep concise with bullet points, and update via `gh pr edit` when pushing changes that alter scope.
+- **All documentation in English**: Commit messages, PR descriptions, issue bodies, review comments, and any GitHub-facing content must be written in English. Keep concise with bullet points, and update PR descriptions via `gh pr edit` when pushing changes that alter scope.
 - **After PR merge**: `git fetch upstream` → `git checkout master` → `git rebase upstream/master` → `git push origin master` → delete feature branch locally and remotely.

--- a/lib/context/trace/span-repository.js
+++ b/lib/context/trace/span-repository.js
@@ -86,6 +86,10 @@ class SpanRepository {
             return
         }
         const builder = new ExceptionMetaDataBuilder(spanBuilder.getTraceRoot())
+        const uriTemplate = spanBuilder.getTraceRoot().getEnricher('uriStats.uriTemplate')
+        if (uriTemplate) {
+            builder.setUriTemplate(uriTemplate)
+        }
         exceptions.forEach(exception => builder.addException(exception))
         this.dataSender.send(builder.build())
     }

--- a/test/instrumentation/module/express.test.js
+++ b/test/instrumentation/module/express.test.js
@@ -221,7 +221,7 @@ function throwHandleTest(trace, t) {
   t.equal(actualTransactionId.getAgentstarttime(), trace.spanBuilder.traceRoot.getTraceId().getAgentStartTime(), `ExceptionMetaData transactionId agentStarttime ${actualTransactionId.getAgentstarttime()}`)
   t.equal(actualTransactionId.getSequence(), trace.spanBuilder.traceRoot.getTraceId().getTransactionId(), `ExceptionMetaData transactionId sequence ${actualTransactionId.getSequence()}`)
   t.equal(actualExceptionMetaData.getSpanid(), trace.spanBuilder.traceRoot.getTraceId().getSpanId(), `ExceptionMetaData spanId ${actualExceptionMetaData.getSpanid()}`)
-  t.equal(actualExceptionMetaData.getUritemplate(), 'NULL', 'ExceptionMetaData uriTemplate NULL')
+  t.equal(actualExceptionMetaData.getUritemplate(), '/express3', 'ExceptionMetaData uriTemplate /express3')
 
   const actualExceptions = actualExceptionMetaData.getExceptionsList()
   const actualSpanEventError = trace.spanBuilder.spanEventList[1].exception
@@ -266,7 +266,7 @@ function nextErrorHandleTest(trace, t) {
   t.equal(actualTransactionId.getAgentstarttime(), trace.spanBuilder.traceRoot.getTraceId().getAgentStartTime(), `ExceptionMetaData transactionId agentStarttime ${actualTransactionId.getAgentstarttime()}`)
   t.equal(actualTransactionId.getSequence(), trace.spanBuilder.traceRoot.getTraceId().getTransactionId(), `ExceptionMetaData transactionId sequence ${actualTransactionId.getSequence()}`)
   t.equal(actualExceptionMetaData.getSpanid(), trace.spanBuilder.traceRoot.getTraceId().getSpanId(), `ExceptionMetaData spanId ${actualExceptionMetaData.getSpanid()}`)
-  t.equal(actualExceptionMetaData.getUritemplate(), 'NULL', 'ExceptionMetaData uriTemplate NULL')
+  t.equal(actualExceptionMetaData.getUritemplate(), '/express4', 'ExceptionMetaData uriTemplate /express4')
 
   const actualSpanEventError = trace.spanBuilder.spanEventList[1].exception
   const actualExceptions = actualExceptionMetaData.getExceptionsList()
@@ -750,7 +750,7 @@ function throwHandleTestWithoutCallSite(trace, t) {
   t.equal(actualTransansactionId.getAgentstarttime(), trace.spanBuilder.traceRoot.getTraceId().getAgentStartTime(), `ExceptionMetaData transactionId agentStartTime ${actualTransansactionId.getAgentstarttime()}`)
   t.equal(actualTransansactionId.getSequence(), trace.spanBuilder.traceRoot.getTraceId().getTransactionId(), `ExceptionMetaData transactionId sequence ${actualTransansactionId.getSequence()}`)
   t.equal(actualExceptionMetaData.getSpanid(), trace.spanBuilder.traceRoot.getTraceId().getSpanId(), `ExceptionMetaData spanId ${actualExceptionMetaData.getSpanid()}`)
-  t.equal(actualExceptionMetaData.getUritemplate(), 'NULL', 'ExceptionMetaData uriTemplate NULL')
+  t.equal(actualExceptionMetaData.getUritemplate(), '/express3', 'ExceptionMetaData uriTemplate /express3')
 
   const actualSpanEventError = trace.spanBuilder.spanEventList[1].exception
   const actualExceptions = actualExceptionMetaData.getExceptionsList()
@@ -793,7 +793,7 @@ function nextErrorHandleTestWithoutCallSite(trace, t) {
   t.equal(actualTransactionId.getAgentstarttime(), trace.spanBuilder.traceRoot.getTraceId().getAgentStartTime(), `ExceptionMetaData transactionId agentStartTime ${actualTransactionId.getAgentstarttime()}`)
   t.equal(actualTransactionId.getSequence(), trace.spanBuilder.traceRoot.getTraceId().getTransactionId(), `ExceptionMetaData transactionId sequence ${actualTransactionId.getSequence()}`)
   t.equal(actualExceptionMetaData.getSpanid(), trace.spanBuilder.traceRoot.getTraceId().getSpanId(), `ExceptionMetaData spanId ${actualExceptionMetaData.getSpanid()}`)
-  t.equal(actualExceptionMetaData.getUritemplate(), 'NULL', 'ExceptionMetaData uriTemplate NULL')
+  t.equal(actualExceptionMetaData.getUritemplate(), '/express4', 'ExceptionMetaData uriTemplate /express4')
 
   const actualSpanEventError = trace.spanBuilder.spanEventList[1].exception
   const actualExceptions = actualExceptionMetaData.getExceptionsList()
@@ -1321,7 +1321,7 @@ test('Functional Test: requestExceptionMetaData should deliver converted excepti
         t.ok(exceptionMetaData, 'ExceptionMetaData should be delivered to collector')
         t.ok(exceptionMetaData.getTransactionid(), 'transactionId should exist')
         t.ok(exceptionMetaData.getSpanid(), 'spanId should exist')
-        t.equal(exceptionMetaData.getUritemplate(), 'NULL', 'uriTemplate should be NULL by default')
+        t.equal(exceptionMetaData.getUritemplate(), '/exception/unhandled', 'uriTemplate should be route path')
 
         const exceptions = exceptionMetaData.getExceptionsList()
         t.equal(exceptions.length, 1, 'exceptions length should be 1')

--- a/test/instrumentation/module/koa.test.js
+++ b/test/instrumentation/module/koa.test.js
@@ -417,6 +417,63 @@ test('Should aggregate URI stats for DisableTrace in Koa', function (t) {
   })
 })
 
+test('Should record ExceptionMetaData with uriTemplate when route throws in Koa', function (t) {
+  agent.bindHttp()
+
+  const PATH = '/integration/exception-meta'
+  const app = new Koa()
+  const router = new Router()
+  let resolveTraceClosed
+  const traceClosed = new Promise((resolve) => {
+    resolveTraceClosed = resolve
+  })
+
+  router.get(PATH, async (ctx) => {
+    agent.callbackTraceClose((trace) => {
+      setImmediate(() => {
+        const actualExceptionMetaData = trace.repository.dataSender.dataSender.actualExceptionMetaData
+        t.ok(actualExceptionMetaData, 'ExceptionMetaData should be sent')
+
+        if (actualExceptionMetaData) {
+          const actualTransactionId = actualExceptionMetaData.getTransactionid()
+          t.ok(actualTransactionId, 'transactionId should exist')
+          t.ok(actualExceptionMetaData.getSpanid(), 'spanId should exist')
+          t.equal(actualExceptionMetaData.getUritemplate(), PATH, 'uriTemplate should be route path')
+
+          const exceptions = actualExceptionMetaData.getExceptionsList()
+          t.equal(exceptions.length, 1, 'exceptions length should be 1')
+          if (exceptions.length > 0) {
+            t.equal(exceptions[0].getExceptionclassname(), 'Error', 'exception class should be Error')
+            t.ok(exceptions[0].getExceptionmessage().includes('koa exception test'), 'exception message should match')
+          }
+        }
+
+        resolveTraceClosed()
+      })
+    })
+    throw new Error('koa exception test')
+  })
+
+  app.use(router.routes()).use(router.allowedMethods())
+
+  const server = app.listen(TEST_ENV.port, async () => {
+    try {
+      await axios.get(getServerUrl(PATH), {
+        timeout: 3000,
+        validateStatus: () => true,
+        httpAgent: new http.Agent({ keepAlive: false }),
+        httpsAgent: new https.Agent({ keepAlive: false }),
+      })
+      await traceClosed
+    } catch (e) {
+      t.fail(e)
+    } finally {
+      server.close()
+      t.end()
+    }
+  })
+})
+
 test('Should count failure in URI stats for DisableTrace in Koa', function (t) {
   agent.bindHttp({
     sampling: { enable: false },

--- a/test/instrumentation/module/undici.test.js
+++ b/test/instrumentation/module/undici.test.js
@@ -210,7 +210,7 @@ test('shimming require(undici) cause by require-in-the-middle package', function
             t.equal(exceptionMetaData.getTransactionid().getAgentstarttime(), actualFetchAPISpan.traceRoot.getTraceId().getAgentStartTime(), `ExceptionMetaData agent start time is ${actualFetchAPISpan.traceRoot.getTraceId().getAgentStartTime()}`)
             t.equal(exceptionMetaData.getTransactionid().getSequence(), actualFetchAPISpan.traceRoot.getTraceId().getTransactionId(), `ExceptionMetaData transaction id is ${actualFetchAPISpan.traceRoot.getTraceId().getTransactionId()}`)
             t.equal(exceptionMetaData.getSpanid(), actualFetchAPISpan.traceRoot.getTraceId().getSpanId(), `ExceptionMetaData span id is ${actualFetchAPISpan.traceRoot.getTraceId().getSpanId()}`)
-            t.equal(exceptionMetaData.getUritemplate(), 'NULL', 'ExceptionMetaData uri template is NULL')
+            t.equal(exceptionMetaData.getUritemplate(), '/outgoing', 'ExceptionMetaData uri template is /outgoing')
 
             const exceptionsList = exceptionMetaData.getExceptionsList()
             t.equal(exceptionsList.length, 1, 'ExceptionMetaData exceptions length is 1')


### PR DESCRIPTION
## Summary

- Retrieve `uriStats.uriTemplate` from traceRoot enricher and set it on `ExceptionMetaDataBuilder`
- Previously always sent `'NULL'`; now sends actual route path (e.g. `/express3`, `/api/error`)
- Consistent with Java agent (`traceRoot.shared.getUriTemplate()`) and Go agent (`span.urlStat.Url`)
- Update CLAUDE.md: all GitHub-facing content must be in English

## Test plan

- [x] Express 347 tests pass (updated 5 uriTemplate assertions)
- [x] Koa 50 tests pass (added ExceptionMetaData with uriTemplate test)
- [x] Undici test updated (uriTemplate assertion)

Closes #457