### PR TITLE
[#469] Support Error.cause chain in ExceptionMetaData

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,3 +71,4 @@ TypeScript declarations are in `index.d.ts` and per-module `.d.ts` files; genera
 - **Testing**: New features and bug fixes must include functional tests for all supported web frameworks (Express, Koa, Next.js). Run relevant test files and confirm they pass before committing.
 - **All documentation in English**: Commit messages, PR descriptions, issue bodies, review comments, and any GitHub-facing content must be written in English. Keep concise with bullet points, and update PR descriptions via `gh pr edit` when pushing changes that alter scope.
 - **After PR merge**: `git fetch upstream` → `git checkout master` → `git rebase upstream/master` → `git push origin master` → delete feature branch locally and remotely.
+- **New tasks**: When starting a new feature or issue without an existing GitHub issue, create one first via `gh issue create`.

--- a/README.md
+++ b/README.md
@@ -87,6 +87,8 @@ PINPOINT_FEATURES_URI_STATS_HTTP_METHOD | false | Include HTTP method in URI key
 PINPOINT_FEATURES_URI_STATS_CAPACITY | 1000 | Max URI patterns per snapshot window.
 PINPOINT_FEATURES_URI_STATS_TIME_WINDOW |  | Snapshot window in ms (default: `30000`).
 PINPOINT_FEATURES_URI_STATS_USE_USER_INPUT | true | Use user-defined URI template when available. Set a custom URI template on `req`: `req['pinpoint.metric.uri-template'] = '/my/uri'`
+PINPOINT_FEATURES_EXCEPTION_STATS | true | Set `false` to disable exception stats. When `exceptionStats` config is not set, the feature is disabled.
+PINPOINT_FEATURES_EXCEPTION_STATS_MAX_DEPTH | 10 | Max depth for `Error.cause` chain traversal.
 
 Custom URI template example:
 ```javascript

--- a/demo/express/routes/index.js
+++ b/demo/express/routes/index.js
@@ -138,4 +138,12 @@ router.get('/exception/unhandled', function (req, res, next) {
   next(error)
 })
 
+router.get('/exception/cause-chain', function (req, res, next) {
+  const rootCause = new TypeError('database connection refused')
+  const middle = new Error('failed to fetch user', { cause: rootCause })
+  const error = new Error('request handler failed', { cause: middle })
+  error.status = 500
+  next(error)
+})
+
 module.exports = router

--- a/lib/context/trace/exception-builder.js
+++ b/lib/context/trace/exception-builder.js
@@ -32,12 +32,12 @@ class Frame {
 }
 
 class Exception {
-    constructor(errorClassName, errorMessage, startTime) {
+    constructor(errorClassName, errorMessage, startTime, exceptionId, exceptionDepth) {
         this.errorClassName = errorClassName
         this.errorMessage = errorMessage
         this.startTime = startTime
-        this.exceptionId = nextExceptionId()
-        this.exceptionDepth = 1
+        this.exceptionId = exceptionId ?? nextExceptionId()
+        this.exceptionDepth = exceptionDepth ?? 0
         this.frameStack = []
     }
 
@@ -62,26 +62,52 @@ class Exception {
 
 const nullErrorClassName = 'unknown'
 const nullErrorMessage = ''
+const defaultMaxDepth = 10
 
 class ExceptionBuilder {
-    constructor(error) {
+    constructor(error, maxDepth) {
         this.error = error
+        this.maxDepth = maxDepth ?? defaultMaxDepth
     }
 
     build() {
-        if (!this.error || typeof this.error.stack !== 'string') {
-            return new Exception(nullErrorClassName, nullErrorMessage, Date.now())
+        return this.buildChain()
+    }
+
+    buildChain() {
+        const exceptions = []
+        const exceptionId = nextExceptionId()
+        let current = this.error
+        let depth = 0
+
+        while (current && depth < this.maxDepth) {
+            const exception = this.buildSingleException(current, exceptionId, depth)
+            exceptions.push(exception)
+            current = current.cause
+            depth++
         }
 
-        const stack = this.error.stack.split(/\r?\n/)
+        if (exceptions.length === 0) {
+            exceptions.push(new Exception(nullErrorClassName, nullErrorMessage, Date.now(), exceptionId, 0))
+        }
+
+        return exceptions
+    }
+
+    buildSingleException(error, exceptionId, depth) {
+        if (!error || typeof error.stack !== 'string') {
+            return new Exception(nullErrorClassName, nullErrorMessage, Date.now(), exceptionId, depth)
+        }
+
+        const stack = error.stack.split(/\r?\n/)
         if (stack.length < 1) {
-            return new Exception(nullErrorClassName, nullErrorMessage, Date.now())
+            return new Exception(nullErrorClassName, nullErrorMessage, Date.now(), exceptionId, depth)
         }
 
         const className = this.extractErrorClassName(stack[0])
-        const message = this.error.message ?? nullErrorMessage
+        const message = error.message ?? nullErrorMessage
 
-        const exception = new Exception(className, message, Date.now())
+        const exception = new Exception(className, message, Date.now(), exceptionId, depth)
         exception.frameStack = stack.slice(1).map(callSite => {
             const { type, location, fileName, lineNumber, functionName, methodName } = namedGroupCallSite(callSite.trim())
 
@@ -108,7 +134,6 @@ class ExceptionBuilder {
         const match = /^([^:\s]+):/.exec(firstLine)
         return match && match[1] ? match[1].trim() : nullErrorClassName
     }
-
 }
 
 module.exports = {

--- a/lib/context/trace/exception-stats-config-builder.js
+++ b/lib/context/trace/exception-stats-config-builder.js
@@ -1,0 +1,77 @@
+/**
+ * Pinpoint Node.js Agent
+ * Copyright 2020-present NAVER Corp.
+ * Apache License v2.0
+ */
+
+'use strict'
+
+const { valueOfBoolean, valueOfNumber } = require('../../config-builder')
+
+class ExceptionStatsConfig {
+    constructor(config) {
+        Object.assign(this, config)
+    }
+
+    isExceptionStatsEnabled() {
+        return true
+    }
+
+    getMaxDepth() {
+        return this.maxDepth ?? 10
+    }
+}
+
+class DisableExceptionStatsConfig {
+    isExceptionStatsEnabled() {
+        return false
+    }
+
+    getMaxDepth() {
+        return 10
+    }
+}
+
+class ExceptionStatsConfigBuilder {
+    constructor(config) {
+        this.config = config
+    }
+
+    build() {
+        const envExceptionStats = {
+            enabled: valueOfBoolean('PINPOINT_FEATURES_EXCEPTION_STATS'),
+            maxDepth: valueOfNumber('PINPOINT_FEATURES_EXCEPTION_STATS_MAX_DEPTH'),
+        }
+        const normalizedEnv = Object.fromEntries(Object.entries(envExceptionStats).filter(([, value]) => value !== undefined))
+
+        const globalConfig = this.config ?? {}
+        const hasJsonConfig = globalConfig.features?.exceptionStats !== undefined
+        const hasEnvConfig = Object.keys(normalizedEnv).length > 0
+        const exceptionStats = globalConfig.features?.exceptionStats || {}
+
+        const merged = {
+            ...exceptionStats,
+            ...normalizedEnv
+        }
+
+        if (!hasJsonConfig && !hasEnvConfig) {
+            return new DisableExceptionStatsConfig()
+        }
+
+        if (merged.enabled === false) {
+            return new DisableExceptionStatsConfig()
+        }
+
+        const validMaxDepth = isValidMaxDepth(merged.maxDepth) ? merged.maxDepth : 10
+        return new ExceptionStatsConfig({ ...merged, maxDepth: validMaxDepth })
+    }
+}
+
+function isValidMaxDepth(maxDepth) {
+    return typeof maxDepth === 'number' && Number.isFinite(maxDepth) && maxDepth > 0
+}
+
+module.exports = {
+    ExceptionStatsConfigBuilder,
+    DisableExceptionStatsConfig
+}

--- a/lib/context/trace/span-event-recorder.js
+++ b/lib/context/trace/span-event-recorder.js
@@ -128,9 +128,11 @@ class SpanEventRecorder {
             shared.maskErrorCode(1)
         }
 
-        const exception = new ExceptionBuilder(error).build()
-        this.spanEventBuilder.setException(exception)
-        this.spanEventBuilder.addAnnotation(exception.exceptionIdAnnotation())
+        const exceptions = new ExceptionBuilder(error).build()
+        this.spanEventBuilder.setException(exceptions)
+        if (exceptions.length > 0) {
+            this.spanEventBuilder.addAnnotation(exceptions[0].exceptionIdAnnotation())
+        }
     }
 
     recordSqlInfo(sql, bindString) {

--- a/lib/context/trace/span-repository.js
+++ b/lib/context/trace/span-repository.js
@@ -63,6 +63,7 @@ class SpanRepository {
         const exceptions = spanEvents
             .map(spanEvent => spanEvent?.exception)
             .filter(Boolean)
+            .flat()
 
         if (exceptions.length === 0) {
             return []

--- a/lib/pinpoint-config-default.json
+++ b/lib/pinpoint-config-default.json
@@ -34,6 +34,9 @@
             "capacity": 1000,
             "useUserInput": true
         },
+        "exceptionStats": {
+            "maxDepth": 10
+        },
         "logLevels": {
             "default-logger": "WARN",
             "grpcLogger": "SILENT"

--- a/test/context/make-method-descriptor-builder.test.js
+++ b/test/context/make-method-descriptor-builder.test.js
@@ -42,7 +42,7 @@ const buildException = (stack) => {
     const [firstLine, ...rest] = stack.split(/\r?\n/)
     err.message = firstLine.replace(/^Error:?\s*/, '')
     err.stack = [firstLine, ...rest].join('\n')
-    return new ExceptionBuilder(err).build()
+    return new ExceptionBuilder(err).build()[0]
 }
 
 test('express stack: ensure computed method names and file/line are preserved in frames', (t) => {

--- a/test/context/trace/exception-builder.test.js
+++ b/test/context/trace/exception-builder.test.js
@@ -22,7 +22,8 @@ error.stack = `Error: error case
 
 test('ExceptionBuilder Test - snapshot-like multiline', (t) => {
     t.plan(13)
-    const actual = new ExceptionBuilder(error).build()
+    const exceptions = new ExceptionBuilder(error).build()
+    const actual = exceptions[0]
     t.equal(actual.errorClassName, 'Error', `Error class name is ${actual.errorClassName}`)
     t.equal(actual.errorMessage, 'error case', `Error message is ${actual.errorMessage}`)
     t.equal(actual.frameStack.length, 10, `Frame stack length is ${actual.frameStack.length}`)
@@ -108,7 +109,7 @@ test('ExceptionBuilder should use fileName as className fallback and <anonymous>
     at Layer.handle [as handle_request] (/Users/app/node_modules/express/lib/router/layer.js:95:5)
     at next (/Users/app/node_modules/express/lib/router/route.js:149:13)`
 
-    const actual = new ExceptionBuilder(err).build()
+    const actual = new ExceptionBuilder(err).build()[0]
 
     // Frame without type and functionName: className=fileName, methodName='<anonymous>'
     const frame0 = actual.frameStack[0]
@@ -124,6 +125,56 @@ test('ExceptionBuilder should use fileName as className fallback and <anonymous>
     const frame2 = actual.frameStack[2]
     t.equal(frame2.className, 'route.js', 'className should fallback to fileName when type is undefined')
     t.equal(frame2.methodName, 'next', 'methodName should be functionName when present')
+
+    t.end()
+})
+
+test('ExceptionBuilder should walk error.cause chain', (t) => {
+    const rootCause = new Error('root cause')
+    rootCause.stack = 'RangeError: root cause\n    at Object.validate (/Users/app/validator.js:10:5)'
+
+    const middleError = new Error('middle error', { cause: rootCause })
+    middleError.stack = 'TypeError: middle error\n    at Object.parse (/Users/app/parser.js:20:5)'
+
+    const topError = new Error('top error', { cause: middleError })
+    topError.stack = 'Error: top error\n    at Object.handler (/Users/app/handler.js:30:5)'
+
+    const exceptions = new ExceptionBuilder(topError).build()
+
+    t.equal(exceptions.length, 3, 'should have 3 exceptions in chain')
+
+    t.equal(exceptions[0].errorClassName, 'Error', 'depth 0: Error')
+    t.equal(exceptions[0].errorMessage, 'top error', 'depth 0: top error')
+    t.equal(exceptions[0].exceptionDepth, 0, 'depth 0')
+
+    t.equal(exceptions[1].errorClassName, 'TypeError', 'depth 1: TypeError')
+    t.equal(exceptions[1].errorMessage, 'middle error', 'depth 1: middle error')
+    t.equal(exceptions[1].exceptionDepth, 1, 'depth 1')
+
+    t.equal(exceptions[2].errorClassName, 'RangeError', 'depth 2: RangeError')
+    t.equal(exceptions[2].errorMessage, 'root cause', 'depth 2: root cause')
+    t.equal(exceptions[2].exceptionDepth, 2, 'depth 2')
+
+    const sharedId = exceptions[0].exceptionId
+    t.equal(exceptions[1].exceptionId, sharedId, 'all exceptions share same exceptionId')
+    t.equal(exceptions[2].exceptionId, sharedId, 'all exceptions share same exceptionId')
+
+    t.end()
+})
+
+test('ExceptionBuilder should respect maxDepth', (t) => {
+    const cause2 = new Error('cause2')
+    cause2.stack = 'Error: cause2\n    at c (/app.js:3:1)'
+    const cause1 = new Error('cause1', { cause: cause2 })
+    cause1.stack = 'Error: cause1\n    at b (/app.js:2:1)'
+    const top = new Error('top', { cause: cause1 })
+    top.stack = 'Error: top\n    at a (/app.js:1:1)'
+
+    const exceptions = new ExceptionBuilder(top, 2).build()
+
+    t.equal(exceptions.length, 2, 'should be limited to maxDepth=2')
+    t.equal(exceptions[0].errorMessage, 'top', 'depth 0')
+    t.equal(exceptions[1].errorMessage, 'cause1', 'depth 1')
 
     t.end()
 })

--- a/test/context/trace/exception-stats-config-builder.test.js
+++ b/test/context/trace/exception-stats-config-builder.test.js
@@ -1,0 +1,74 @@
+/**
+ * Pinpoint Node.js Agent
+ * Copyright 2020-present NAVER Corp.
+ * Apache License v2.0
+ */
+
+const test = require('tape')
+const { ExceptionStatsConfigBuilder } = require('../../../lib/context/trace/exception-stats-config-builder')
+
+test('ExceptionStatsConfigBuilder should return DisableExceptionStatsConfig when no config', (t) => {
+    const config = new ExceptionStatsConfigBuilder({}).build()
+    t.equal(config.isExceptionStatsEnabled(), false, 'should be disabled')
+    t.equal(config.getMaxDepth(), 10, 'should return default maxDepth')
+    t.end()
+})
+
+test('ExceptionStatsConfigBuilder should return DisableExceptionStatsConfig when enabled is false', (t) => {
+    const config = new ExceptionStatsConfigBuilder({
+        features: { exceptionStats: { enabled: false } }
+    }).build()
+    t.equal(config.isExceptionStatsEnabled(), false, 'should be disabled')
+    t.end()
+})
+
+test('ExceptionStatsConfigBuilder should return enabled config with defaults', (t) => {
+    const config = new ExceptionStatsConfigBuilder({
+        features: { exceptionStats: {} }
+    }).build()
+    t.equal(config.isExceptionStatsEnabled(), true, 'should be enabled')
+    t.equal(config.getMaxDepth(), 10, 'default maxDepth is 10')
+    t.end()
+})
+
+test('ExceptionStatsConfigBuilder should use custom maxDepth', (t) => {
+    const config = new ExceptionStatsConfigBuilder({
+        features: { exceptionStats: { maxDepth: 5 } }
+    }).build()
+    t.equal(config.isExceptionStatsEnabled(), true, 'should be enabled')
+    t.equal(config.getMaxDepth(), 5, 'custom maxDepth is 5')
+    t.end()
+})
+
+test('ExceptionStatsConfigBuilder should override with env vars', (t) => {
+    process.env.PINPOINT_FEATURES_EXCEPTION_STATS = 'true'
+    process.env.PINPOINT_FEATURES_EXCEPTION_STATS_MAX_DEPTH = '3'
+
+    const config = new ExceptionStatsConfigBuilder({}).build()
+    t.equal(config.isExceptionStatsEnabled(), true, 'env var enables')
+    t.equal(config.getMaxDepth(), 3, 'env var maxDepth is 3')
+
+    delete process.env.PINPOINT_FEATURES_EXCEPTION_STATS
+    delete process.env.PINPOINT_FEATURES_EXCEPTION_STATS_MAX_DEPTH
+    t.end()
+})
+
+test('ExceptionStatsConfigBuilder env var false should disable', (t) => {
+    process.env.PINPOINT_FEATURES_EXCEPTION_STATS = 'false'
+
+    const config = new ExceptionStatsConfigBuilder({
+        features: { exceptionStats: { maxDepth: 5 } }
+    }).build()
+    t.equal(config.isExceptionStatsEnabled(), false, 'env var disables')
+
+    delete process.env.PINPOINT_FEATURES_EXCEPTION_STATS
+    t.end()
+})
+
+test('ExceptionStatsConfigBuilder should fallback invalid maxDepth to default', (t) => {
+    const config = new ExceptionStatsConfigBuilder({
+        features: { exceptionStats: { maxDepth: -1 } }
+    }).build()
+    t.equal(config.getMaxDepth(), 10, 'invalid maxDepth falls back to 10')
+    t.end()
+})

--- a/test/instrumentation/module/express.test.js
+++ b/test/instrumentation/module/express.test.js
@@ -224,7 +224,7 @@ function throwHandleTest(trace, t) {
   t.equal(actualExceptionMetaData.getUritemplate(), '/express3', 'ExceptionMetaData uriTemplate /express3')
 
   const actualExceptions = actualExceptionMetaData.getExceptionsList()
-  const actualSpanEventError = trace.spanBuilder.spanEventList[1].exception
+  const actualSpanEventError = trace.spanBuilder.spanEventList[1].exception[0]
   t.equal(actualExceptions.length, 1, 'ExceptionMetaData exceptions length 1')
   t.equal(actualExceptions[0].getExceptionclassname(), actualSpanEventError.errorClassName, `ExceptionMetaData exception class name ${actualSpanEventError.errorClassName}`)
   t.equal(actualExceptions[0].getExceptionmessage(), actualSpanEventError.errorMessage, `ExceptionMetaData exception message ${actualSpanEventError.errorMessage}`)
@@ -268,7 +268,7 @@ function nextErrorHandleTest(trace, t) {
   t.equal(actualExceptionMetaData.getSpanid(), trace.spanBuilder.traceRoot.getTraceId().getSpanId(), `ExceptionMetaData spanId ${actualExceptionMetaData.getSpanid()}`)
   t.equal(actualExceptionMetaData.getUritemplate(), '/express4', 'ExceptionMetaData uriTemplate /express4')
 
-  const actualSpanEventError = trace.spanBuilder.spanEventList[1].exception
+  const actualSpanEventError = trace.spanBuilder.spanEventList[1].exception[0]
   const actualExceptions = actualExceptionMetaData.getExceptionsList()
   t.equal(actualExceptions.length, 1, 'ExceptionMetaData exceptions length 1')
   t.equal(actualExceptions[0].getExceptionclassname(), actualSpanEventError.errorClassName, `ExceptionMetaData exception class name ${actualSpanEventError.errorClassName}`)
@@ -286,7 +286,7 @@ function unhandledExceptionStatsFrameTest(trace, t) {
   t.equal(actualExceptions.length, 1, 'ExceptionMetaData exceptions length 1')
 
   const actualException = actualExceptions[0]
-  const actualSpanEventError = trace.spanBuilder.spanEventList[1].exception
+  const actualSpanEventError = trace.spanBuilder.spanEventList[1].exception[0]
 
   t.equal(actualException.getExceptionmessage(), actualSpanEventError.errorMessage, 'ExceptionMetaData exception message should match span event error message')
   t.equal(actualException.getExceptionid(), actualSpanEventError.exceptionId, 'ExceptionMetaData exception id should match span event exception id')
@@ -752,7 +752,7 @@ function throwHandleTestWithoutCallSite(trace, t) {
   t.equal(actualExceptionMetaData.getSpanid(), trace.spanBuilder.traceRoot.getTraceId().getSpanId(), `ExceptionMetaData spanId ${actualExceptionMetaData.getSpanid()}`)
   t.equal(actualExceptionMetaData.getUritemplate(), '/express3', 'ExceptionMetaData uriTemplate /express3')
 
-  const actualSpanEventError = trace.spanBuilder.spanEventList[1].exception
+  const actualSpanEventError = trace.spanBuilder.spanEventList[1].exception[0]
   const actualExceptions = actualExceptionMetaData.getExceptionsList()
   t.equal(actualExceptions.length, 1, 'ExceptionMetaData exceptions length 1')
   t.equal(actualExceptions[0].getExceptionclassname(), actualSpanEventError.errorClassName, `ExceptionMetaData exception class name ${actualSpanEventError.errorClassName}`)
@@ -795,7 +795,7 @@ function nextErrorHandleTestWithoutCallSite(trace, t) {
   t.equal(actualExceptionMetaData.getSpanid(), trace.spanBuilder.traceRoot.getTraceId().getSpanId(), `ExceptionMetaData spanId ${actualExceptionMetaData.getSpanid()}`)
   t.equal(actualExceptionMetaData.getUritemplate(), '/express4', 'ExceptionMetaData uriTemplate /express4')
 
-  const actualSpanEventError = trace.spanBuilder.spanEventList[1].exception
+  const actualSpanEventError = trace.spanBuilder.spanEventList[1].exception[0]
   const actualExceptions = actualExceptionMetaData.getExceptionsList()
   t.equal(actualExceptions.length, 1, 'ExceptionMetaData exceptions length 1')
   t.equal(actualExceptions[0].getExceptionclassname(), actualSpanEventError.errorClassName, `ExceptionMetaData exception class name ${actualSpanEventError.errorClassName}`)
@@ -1330,7 +1330,7 @@ test('Functional Test: requestExceptionMetaData should deliver converted excepti
         t.equal(exception.getExceptionclassname(), 'Error', 'exception class should be Error')
         t.equal(exception.getExceptionmessage(), 'Pinpoint unhandled exception test route', 'exception message should match')
         t.ok(exception.getExceptionid() > 0, 'exception id should be greater than 0')
-        t.equal(exception.getExceptiondepth(), 1, 'exception depth should be 1')
+        t.equal(exception.getExceptiondepth(), 0, 'exception depth should be 0')
 
         const stackTraceElements = exception.getStacktraceelementList()
         t.ok(stackTraceElements.length > 0, 'stackTraceElements should not be empty')
@@ -1415,6 +1415,93 @@ test('Functional Test: requestExceptionMetaData should deliver converted excepti
       try {
         const serverPort = server.address().port
         const response = await axios.get(`http://localhost:${serverPort}/exception/unhandled`, {
+          validateStatus: () => true,
+          httpAgent: new http.Agent({ keepAlive: false }),
+          httpsAgent: new https.Agent({ keepAlive: false }),
+        })
+
+        t.equal(response.status, 500, 'route should return 500')
+        await metadataReceivedPromise
+      } catch (error) {
+        t.fail(error?.stack || error?.message || String(error))
+      } finally {
+        server.close(() => {
+          dataSender?.close()
+          collectorServer.forceShutdown()
+          t.end()
+        })
+      }
+    })
+  })
+})
+
+test('Functional Test: requestExceptionMetaData should deliver error.cause chain', (t) => {
+  const collectorServer = new grpc.Server()
+  let dataSender
+  let metadataReceived
+  const metadataReceivedPromise = new Promise((resolve, reject) => {
+    metadataReceived = { resolve, reject }
+  })
+
+  collectorServer.addService(services.MetadataService, {
+    requestExceptionMetaData: (call, callback) => {
+      callback(null, new spanMessages.PResult())
+
+      try {
+        const exceptionMetaData = call.request
+        t.ok(exceptionMetaData, 'ExceptionMetaData should be delivered')
+
+        const exceptions = exceptionMetaData.getExceptionsList()
+        t.equal(exceptions.length, 2, 'should have 2 exceptions in cause chain')
+
+        const top = exceptions[0]
+        t.equal(top.getExceptionclassname(), 'Error', 'top exception class is Error')
+        t.equal(top.getExceptionmessage(), 'request failed', 'top exception message')
+        t.equal(top.getExceptiondepth(), 0, 'top exception depth is 0')
+
+        const cause = exceptions[1]
+        t.equal(cause.getExceptionclassname(), 'TypeError', 'cause class is TypeError')
+        t.equal(cause.getExceptionmessage(), 'root cause', 'cause message')
+        t.equal(cause.getExceptiondepth(), 1, 'cause depth is 1')
+
+        t.equal(top.getExceptionid(), cause.getExceptionid(), 'shared exceptionId')
+        t.ok(cause.getStacktraceelementList().length > 0, 'cause should have stack trace')
+
+        metadataReceived.resolve()
+      } catch (error) {
+        metadataReceived.reject(error)
+      }
+    }
+  })
+
+  collectorServer.bindAsync('localhost:0', grpc.ServerCredentials.createInsecure(), (err, port) => {
+    if (err) {
+      t.fail(err)
+      collectorServer.forceShutdown()
+      t.end()
+      return
+    }
+
+    dataSender = new GrpcDataSenderBuilder(port)
+      .enableExceptionMetaData()
+      .build()
+    agent.bindHttp(dataSender)
+
+    const app = new express()
+    app.get('/exception/cause-chain', function (req, res, next) {
+      const rootCause = new TypeError('root cause')
+      const error = new Error('request failed', { cause: rootCause })
+      error.status = 500
+      next(error)
+    })
+    app.use(function (err, req, res, next) {
+      res.status(500).send('error')
+    })
+
+    const server = app.listen(0, async () => {
+      try {
+        const serverPort = server.address().port
+        const response = await axios.get(`http://localhost:${serverPort}/exception/cause-chain`, {
           validateStatus: () => true,
           httpAgent: new http.Agent({ keepAlive: false }),
           httpsAgent: new https.Agent({ keepAlive: false }),

--- a/test/instrumentation/module/koa.test.js
+++ b/test/instrumentation/module/koa.test.js
@@ -13,6 +13,10 @@ const annotationKey = require('../../../lib/constant/annotation-key')
 const apiMetaService = require('../../../lib/context/api-meta-service')
 const MethodDescriptorBuilder = require('../../../lib/context/method-descriptor-builder')
 const { UriStatsRepositoryBuilder } = require('../../../lib/metric/uri/uri-stats-repository')
+const grpc = require('@grpc/grpc-js')
+const services = require('../../../lib/data/v1/Service_grpc_pb')
+const spanMessages = require('../../../lib/data/v1/Span_pb')
+const GrpcDataSenderBuilder = require('../../client/grpc-data-sender-builder')
 const http = require('http')
 const https = require('https')
 
@@ -543,5 +547,94 @@ test('Should count failure in URI stats for DisableTrace in Koa', function (t) {
       server.close()
       t.end()
     }
+  })
+})
+
+test('Functional Test: requestExceptionMetaData should deliver error.cause chain in Koa', (t) => {
+  const collectorServer = new grpc.Server()
+  let dataSender
+  let metadataReceived
+  const metadataReceivedPromise = new Promise((resolve, reject) => {
+    metadataReceived = { resolve, reject }
+  })
+
+  collectorServer.addService(services.SpanService, {
+    sendSpan: function (call) {
+      call.on('data', function () {})
+    },
+  })
+  collectorServer.addService(services.MetadataService, {
+    requestExceptionMetaData: (call, callback) => {
+      callback(null, new spanMessages.PResult())
+
+      try {
+        const exceptionMetaData = call.request
+        t.ok(exceptionMetaData, 'ExceptionMetaData should be delivered')
+
+        const exceptions = exceptionMetaData.getExceptionsList()
+        t.equal(exceptions.length, 2, 'should have 2 exceptions in cause chain')
+
+        const top = exceptions[0]
+        t.equal(top.getExceptionclassname(), 'Error', 'top exception class is Error')
+        t.equal(top.getExceptionmessage(), 'koa gRPC request failed', 'top exception message')
+        t.equal(top.getExceptiondepth(), 0, 'top exception depth is 0')
+
+        const cause = exceptions[1]
+        t.equal(cause.getExceptionclassname(), 'TypeError', 'cause class is TypeError')
+        t.equal(cause.getExceptionmessage(), 'koa gRPC root cause', 'cause message')
+        t.equal(cause.getExceptiondepth(), 1, 'cause depth is 1')
+
+        t.equal(top.getExceptionid(), cause.getExceptionid(), 'shared exceptionId')
+        t.ok(cause.getStacktraceelementList().length > 0, 'cause should have stack trace')
+
+        metadataReceived.resolve()
+      } catch (error) {
+        metadataReceived.reject(error)
+      }
+    }
+  })
+
+  collectorServer.bindAsync('localhost:0', grpc.ServerCredentials.createInsecure(), (err, port) => {
+    if (err) {
+      t.fail(err)
+      collectorServer.forceShutdown()
+      t.end()
+      return
+    }
+
+    dataSender = new GrpcDataSenderBuilder(port)
+      .enableExceptionMetaData()
+      .build()
+    agent.bindHttp(dataSender)
+
+    const app = new Koa()
+    const router = new Router()
+
+    router.get('/exception/cause-chain', async (ctx) => {
+      const rootCause = new TypeError('koa gRPC root cause')
+      throw new Error('koa gRPC request failed', { cause: rootCause })
+    })
+
+    app.use(router.routes()).use(router.allowedMethods())
+
+    const server = app.listen(0, async () => {
+      try {
+        const serverPort = server.address().port
+        await axios.get(`http://localhost:${serverPort}/exception/cause-chain`, {
+          validateStatus: () => true,
+          httpAgent: new http.Agent({ keepAlive: false }),
+          httpsAgent: new https.Agent({ keepAlive: false }),
+        })
+        await metadataReceivedPromise
+      } catch (error) {
+        t.fail(error?.stack || error?.message || String(error))
+      } finally {
+        server.close(() => {
+          dataSender?.close()
+          collectorServer.forceShutdown()
+          t.end()
+        })
+      }
+    })
   })
 })

--- a/test/instrumentation/module/undici.test.js
+++ b/test/instrumentation/module/undici.test.js
@@ -215,7 +215,7 @@ test('shimming require(undici) cause by require-in-the-middle package', function
             const exceptionsList = exceptionMetaData.getExceptionsList()
             t.equal(exceptionsList.length, 1, 'ExceptionMetaData exceptions length is 1')
             const actualException = exceptionsList[0]
-            const spanEventException = actualFetchAPISpan.spanEventList[1].exception
+            const spanEventException = actualFetchAPISpan.spanEventList[1].exception[0]
             t.equal(actualException.getExceptionclassname(), spanEventException.errorClassName, `ExceptionMetaData exception class name is ${spanEventException.errorClassName}`)
             t.equal(actualException.getExceptionmessage(), spanEventException.errorMessage, `ExceptionMetaData exception message is ${spanEventException.errorMessage}`)
             t.equal(actualException.getExceptiondepth(), spanEventException.exceptionDepth, `ExceptionMetaData exception depth is ${spanEventException.exceptionDepth}`)
@@ -266,6 +266,70 @@ test('shimming require(undici) cause by require-in-the-middle package', function
         const server = app.listen(5006, async () => {
             const result = await axios.get('http://localhost:5006/test', { httpsAgent: new http.Agent({ keepAlive: false }) })
             t.equal(result.data, 'Internal Server Error', 'response is test')
+            server.close()
+        })
+    })
+
+    t.teardown(() => {
+        dataSender.close()
+        collectorServer.forceShutdown()
+    })
+})
+
+test('shimming undici: requestExceptionMetaData should deliver error.cause chain', function (t) {
+    const collectorServer = new grpc.Server()
+
+    collectorServer.addService(services.SpanService, {
+        sendSpan: function (call) {
+            call.on('data', function () {})
+        },
+    })
+    collectorServer.addService(services.MetadataService, {
+        requestExceptionMetaData: (call, callback) => {
+            const result = new spanMessages.PResult()
+            callback(null, result)
+
+            const exceptionMetaData = call.request
+            const exceptionsList = exceptionMetaData.getExceptionsList()
+            t.equal(exceptionsList.length, 2, 'should have 2 exceptions in cause chain')
+
+            const top = exceptionsList[0]
+            t.equal(top.getExceptionclassname(), 'Error', 'top exception class is Error')
+            t.equal(top.getExceptionmessage(), 'undici cause top', 'top exception message')
+            t.equal(top.getExceptiondepth(), 0, 'top exception depth is 0')
+
+            const cause = exceptionsList[1]
+            t.equal(cause.getExceptionclassname(), 'TypeError', 'cause class is TypeError')
+            t.equal(cause.getExceptionmessage(), 'undici cause root', 'cause message')
+            t.equal(cause.getExceptiondepth(), 1, 'cause depth is 1')
+
+            t.equal(top.getExceptionid(), cause.getExceptionid(), 'shared exceptionId')
+            t.end()
+        }
+    })
+
+    let dataSender
+    collectorServer.bindAsync('localhost:0', grpc.ServerCredentials.createInsecure(), (err, port) => {
+        dataSender = new GrpcDataSenderBuilder(port)
+            .enableSpan()
+            .enableExceptionMetaData()
+            .build()
+        agent.bindHttp(dataSender)
+
+        const app = new express()
+        app.get('/cause-outgoing', (req, res) => {
+            const rootCause = new TypeError('undici cause root')
+            throw new Error('undici cause top', { cause: rootCause })
+        })
+        app.use(function (err, req, res, next) {
+            res.status(500).send('error')
+        })
+
+        const server = app.listen(5006, async () => {
+            await axios.get('http://localhost:5006/cause-outgoing', {
+                validateStatus: () => true,
+                httpAgent: new http.Agent({ keepAlive: false }),
+            })
             server.close()
         })
     })


### PR DESCRIPTION
## Summary

- Walk `error.cause` chain to create multiple `PException` objects with shared `exceptionId` and incrementing `exceptionDepth` (starting from 0, same as Java agent)
- Add `ExceptionStatsConfig` with on/off toggle and `maxDepth` setting (default: 10)
- When `exceptionStats` config is not set, disable the feature (same pattern as URI Stats)
- Support both JSON config (`features.exceptionStats`) and env vars (`PINPOINT_FEATURES_EXCEPTION_STATS`, `PINPOINT_FEATURES_EXCEPTION_STATS_MAX_DEPTH`)
- Add env vars to README.md

## Test plan

- [x] exception-builder 34 tests pass (incl. cause chain and maxDepth tests)
- [x] exception-stats-config-builder 11 tests pass
- [x] Express 358 tests pass (incl. cause chain gRPC functional test)
- [x] Koa 60 tests pass (incl. cause chain gRPC functional test)
- [x] Undici 280 tests pass (incl. cause chain gRPC functional test)

Closes #469