### PR TITLE
[#412] Fix Deadline exceeded ERROR logs appear even with grpcLogger=SILENT

### DIFF
--- a/lib/client/grpc-data-sender.js
+++ b/lib/client/grpc-data-sender.js
@@ -21,7 +21,7 @@ const cmdMessages = require('../data/v1/Cmd_pb')
 const wrappers = require('google-protobuf/google/protobuf/wrappers_pb')
 const activeRequestRepository = require('../metric/active-request-repository')
 const { setInterval } = require('node:timers/promises')
-const { logError } = require('./grpc-errors')
+const { logError, initializeLogger } = require('./grpc-errors')
 const StreamDeadlineOptionsBuilder = require('./stream-deadline-options-builder')
 const GrpcReadableStreamBuilder = require('./grpc-readable-stream-builder')
 const UnaryDeadlineOptionsBuilder = require('./unary-deadline-options-builder')
@@ -39,7 +39,8 @@ class GrpcDataSender {
     this.collectorSpanPort = collectorSpanPort
     this.agentInfo = agentInfo
     this.config = config
-    this.logger = log.getLogger(LogBuilder.buildGrpcLog())
+    this.logger = log.getLogger(LogBuilder.createGrpcLogBuilder().setConfig(config).build())
+    initializeLogger(this.logger)
 
     this.unaryDeadlineOptionsBuilder = new UnaryDeadlineOptionsBuilder()
     this.initializeClients()

--- a/lib/client/grpc-errors.js
+++ b/lib/client/grpc-errors.js
@@ -11,6 +11,10 @@ const log = require('../utils/log/logger')
 const { LogBuilder } = require('../utils/log/log-builder')
 
 let logger = null
+function initializeLogger(newLogger) {
+    logger = newLogger
+}
+
 function logError(message, error) {
     if (!error) {
         return
@@ -46,5 +50,6 @@ function isDeadlineExceededError(err) {
 module.exports = {
     isCancelledError,
     isDeadlineExceededError,
+    initializeLogger,
     logError
 }

--- a/lib/client/grpc-writable-stream-builder.js
+++ b/lib/client/grpc-writable-stream-builder.js
@@ -9,7 +9,6 @@
 const { logError } = require('./grpc-errors')
 const ExponentialBackoffRetryBuilder = require('./exponential-backoff-retry-builder')
 const log = require('../utils/log/logger')
-const { LogBuilder } = require('../utils/log/log-builder')
 
 class GrpcWritableStream {
     constructor(makeWritableStream) {
@@ -22,7 +21,6 @@ class GrpcWritableStream {
         }).setRetryCallback(() => {
             this.connect()
         }).build()
-        this.logger = log.getLogger(LogBuilder.buildGrpcLog())
     }
 
     connect() {
@@ -45,7 +43,8 @@ class GrpcWritableStream {
 
                 if (error) {
                     if (error.code === 13) {
-                        this.logger.warn('Warning: Collector returned 13 INTERNAL error. Too much Span data may be sent. Try increasing PINPOINT_SAMPLING_RATE to reduce traffic. https://github.com/pinpoint-apm/pinpoint-node-agent/issues/317')
+                        const defaultLogger = log.getLogger()
+                        defaultLogger.warn('Warning: Collector returned 13 INTERNAL error. Too much Span data may be sent. Try increasing PINPOINT_SAMPLING_RATE to reduce traffic. https://github.com/pinpoint-apm/pinpoint-node-agent/issues/317')
                     }
                     logError('clientService callback in GrpcWritableStreamBuilder', error)
                     this.backoffRetry.retry()

--- a/test/client/grpc-errors.test.js
+++ b/test/client/grpc-errors.test.js
@@ -1,0 +1,72 @@
+/**
+ * Pinpoint Node.js Agent
+ * Copyright 2020-present NAVER Corp.
+ * Apache License v2.0
+ */
+
+'use strict'
+
+const test = require('tape')
+const grpc = require('@grpc/grpc-js')
+const logger = require('../../lib/utils/log/logger')
+const { LogBuilder, LogLevel } = require('../../lib/utils/log/log-builder')
+const { ConfigBuilder } = require('../../lib/config-builder')
+const { initializeLogger, logError } = require('../../lib/client/grpc-errors')
+
+test('logError should not dispatch to appender when grpcLogger is SILENT', (t) => {
+    const config = new ConfigBuilder({
+        applicationName: 'test-silent',
+        features: {
+            logLevels: {
+                'grpcLogger': 'SILENT'
+            }
+        }
+    }).build()
+
+    let appendCallCount = 0
+    const capturingAppender = {
+        name: 'grpc-silent-test',
+        loggingLevel: LogLevel.SILENT,
+        debug: () => { appendCallCount++ },
+        info: () => { appendCallCount++ },
+        warn: () => { appendCallCount++ },
+        error: () => { appendCallCount++ }
+    }
+
+    const grpcLog = logger.getLogger(
+        LogBuilder.createGrpcLogBuilder()
+            .setConfig(config)
+            .addAppender(capturingAppender)
+            .build()
+    )
+    initializeLogger(grpcLog)
+
+    t.equal(grpcLog.loglevel.getLevel(), LogLevel.SILENT, 'grpcLogger level should be SILENT')
+
+    let errorCallCount = 0
+    const originalError = grpcLog.error.bind(grpcLog)
+    grpcLog.error = function () {
+        errorCallCount++
+        originalError.apply(null, arguments)
+    }
+
+    t.teardown(() => {
+        grpcLog.error = originalError
+    })
+
+    logError('deadline test', { code: grpc.status.DEADLINE_EXCEEDED })
+    logError('cancelled test', { code: grpc.status.CANCELLED })
+    logError('unavailable test', { code: grpc.status.UNAVAILABLE })
+    logError('generic test', { code: 999, message: 'unknown' })
+
+    t.equal(errorCallCount, 4, 'initializeLogger injected logger should be used for all logError calls')
+    t.equal(appendCallCount, 0, 'SILENT grpcLogger should not dispatch any logs to appender')
+    t.end()
+})
+
+test('logError should skip when error is null or undefined', (t) => {
+    logError('no error', null)
+    logError('no error', undefined)
+    t.pass('logError should not throw when error is null/undefined')
+    t.end()
+})

--- a/test/client/grpc-writable-stream-builder.test.js
+++ b/test/client/grpc-writable-stream-builder.test.js
@@ -1,0 +1,53 @@
+/**
+ * Pinpoint Node.js Agent
+ * Copyright 2020-present NAVER Corp.
+ * Apache License v2.0
+ */
+
+'use strict'
+
+const test = require('tape')
+const { Writable } = require('node:stream')
+const loglevel = require('loglevel')
+const logger = require('../../lib/utils/log/logger')
+const GrpcWritableStreamBuilder = require('../../lib/client/grpc-writable-stream-builder')
+
+class DummyWritable extends Writable {
+    constructor() {
+        super({ objectMode: true })
+    }
+
+    _write(_chunk, _enc, cb) {
+        cb()
+    }
+}
+
+test('error code 13 INTERNAL should be logged via defaultLogger.warn, not grpcLogger', (t) => {
+    t.plan(2)
+
+    const warnMessages = []
+    const originalWarn = loglevel.warn
+    loglevel.warn = function () { warnMessages.push(Array.from(arguments).join(' ')) }
+
+    t.teardown(() => {
+        loglevel.warn = originalWarn
+    })
+
+    const builder = new GrpcWritableStreamBuilder((options, callback) => {
+        const writable = new DummyWritable()
+        setImmediate(() => callback({ code: 13 }))
+        return writable
+    })
+
+    logger.getLogger()
+
+    const stream = builder.build()
+
+    setImmediate(() => {
+        t.equal(warnMessages.length, 1, 'defaultLogger.warn should be called once for INTERNAL error')
+        t.ok(warnMessages[0].includes('Collector returned 13 INTERNAL error'), 'message should mention collector INTERNAL error')
+
+        stream.end()
+        t.end()
+    })
+})


### PR DESCRIPTION
## Summary

- Inject config-aware grpcLogger into `grpc-errors.js` via `initializeLogger()` so SILENT level is respected
- Error code 13 INTERNAL warning uses `defaultLogger.warn` instead of grpcLogger to remain visible
- Remove unused `LogBuilder` import and `this.logger` from `grpc-writable-stream-builder.js`

## Test plan

- [x] grpc-errors 2 tests pass (SILENT appender verification, null/undefined skip)
- [x] grpc-writable-stream-builder 2 tests pass (error code 13 via defaultLogger.warn)
- [x] Express 358, Koa 60, Undici 280 tests pass

Closes #412