### PR TITLE
[#474] Replace end-of-stream with Node.js built-in stream.finished

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to Pinpoint Node.js agent will be documented in this file.
 
 ## [1.4.0] - 2026-03-25
+### Fixed
+- [[#474](https://github.com/pinpoint-apm/pinpoint-node-agent/issues/474)] Replace external `end-of-stream` dependency with Node.js built-in `stream.finished()`.
+
 ### Added
 - [[#398](https://github.com/pinpoint-apm/pinpoint-node-agent/issues/398)] [Error Analysis](https://pinpoint-apm.gitbook.io/pinpoint/documents/error_analysis) — Collect exception stack traces and send to Pinpoint collector for error analysis. Supports `Error.cause` chain traversal (`maxDepth` default: 10). Configure via `features.errorAnalysis` in `pinpoint-config.json` or `PINPOINT_FEATURES_ERROR_ANALYSIS`, `PINPOINT_FEATURES_ERROR_ANALYSIS_MAX_DEPTH` [environment variables](https://github.com/pinpoint-apm/pinpoint-node-agent?tab=readme-ov-file#environment-variables).
 

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -6,7 +6,7 @@
 
 'use strict'
 
-const endOfStream = require('end-of-stream')
+const { finished } = require('node:stream')
 const annotationKey = require('../constant/annotation-key')
 const ServiceType = require('../context/service-type')
 const localStorage = require('./context/local-storage')
@@ -24,7 +24,8 @@ exports.instrumentRequest = function (agent) {
       const requestTrace = new HttpRequestTraceBuilder(agent.getTraceContext(), req).build()
       const trace = requestTrace.makeTrace()
       return localStorage.run(trace, () => {
-        endOfStream(res, function (err) {
+        // https://nodejs.org/api/stream.html#streamfinishedstream-options-callback
+        finished(res, function (err) {
           const spanRecorder = trace.getSpanRecorder()
           spanRecorder.recordEnricher('http', trace.getTraceRoot(), req)
 

--- a/package.json
+++ b/package.json
@@ -84,7 +84,6 @@
   "dependencies": {
     "@grpc/grpc-js": "^1.10.9",
     "@pinpoint-apm/shimmer": "^1.2.2",
-    "end-of-stream": "^1.4.1",
     "google-protobuf": "^3.13.0",
     "internal-ip": "^3.0.1",
     "loglevel": "^1.9.2",


### PR DESCRIPTION
## Summary

- Replace external `end-of-stream` with Node.js built-in `stream.finished()`
- HTTP request/response streams are short-lived, so dangling listeners are cleaned up when the stream is garbage collected
- Remove `end-of-stream` from dependencies

## Test plan

- [x] Express 358 tests pass
- [x] Koa 60 tests pass
- [x] Undici 280 tests pass

Closes #474