### PR TITLE
[#476] Wire ErrorAnalysisConfig into agent via ExceptionEnricher

### DIFF
--- a/index.js
+++ b/index.js
@@ -16,6 +16,8 @@ const { UriStatsConfigBuilder } = require('./lib/metric/uri/uri-stats-config-bui
 const { SpanRecorderEnricher } = require('./lib/metric/uri/span-recorder-enricher')
 const { UriStatsRepositoryBuilder } = require('./lib/metric/uri/uri-stats-repository')
 const { TraceCompletionEnricher } = require('./lib/metric/uri/trace-completion-enricher')
+const { ErrorAnalysisConfigBuilder } = require('./lib/context/trace/error-analysis-config-builder')
+const { ExceptionEnricher } = require('./lib/context/trace/exception-enricher')
 
 const config = new ConfigBuilder().build()
 
@@ -39,6 +41,10 @@ if (uriStatsConfig.isUriStatsEnabled()) {
     })
     agentBuilder.addEnricher(new SpanRecorderEnricher(uriStatsConfig))
     agentBuilder.addEnricher(new TraceCompletionEnricher(uriStatsRepository))
+}
+const errorAnalysisConfig = new ErrorAnalysisConfigBuilder(config).build()
+if (errorAnalysisConfig.isErrorAnalysisEnabled()) {
+    agentBuilder.addEnricher(new ExceptionEnricher(errorAnalysisConfig))
 }
 const agent = agentBuilder.build()
 agent.start()

--- a/lib/context/trace-context.js
+++ b/lib/context/trace-context.js
@@ -32,6 +32,7 @@ class TraceContext {
     this.sqlMetadataService = new SqlMetadataService(dataSender, config)
     this.traceCompletionEnrichers = enrichers.filter(e => typeof e.onComplete === 'function')
     this.spanRecorderEnricher = enrichers.find(e => typeof e.record === 'function')
+    this.spanEventEnricher = enrichers.find(e => typeof e.recordException === 'function')
   }
 
   getAgentInfo() {
@@ -105,7 +106,7 @@ class TraceContext {
     if (this.spanRecorderEnricher) {
       spanRecorder.enricher = this.spanRecorderEnricher
     }
-    return new Trace(spanBuilder, repository, spanRecorder, this.sqlMetadataService)
+    return new Trace(spanBuilder, repository, spanRecorder, this.sqlMetadataService, this.spanEventEnricher)
   }
 
   // DefaultAsyncContext.java: newAsyncContextTrace
@@ -119,7 +120,7 @@ class TraceContext {
     const spanChunkBuilder = new AsyncSpanChunkBuilder(traceRoot, localAsyncId)
       .setApplicationServiceType(this.agentInfo.getApplicationServiceType())
     const repository = new SpanRepository(spanChunkBuilder, this.dataSender)
-    return new ChildTraceBuilder(traceRoot, repository, localAsyncId, this.sqlMetadataService)
+    return new ChildTraceBuilder(traceRoot, repository, localAsyncId, this.sqlMetadataService, this.spanEventEnricher)
   }
 
   // DefaultBaseTraceFactory.java: continueDisableAsyncContextTraceObject

--- a/lib/context/trace/call-stack.js
+++ b/lib/context/trace/call-stack.js
@@ -13,15 +13,16 @@ const SpanEventRecorder = require('./span-event-recorder')
  * DefaultCallStack.java in Java agent
  */
 class CallStack {
-    constructor(traceRoot) {
+    constructor(traceRoot, exceptionEnricher) {
         this.traceRoot = traceRoot
+        this.exceptionEnricher = exceptionEnricher
         this.stack = []
         this.sequence = 0
         this.depth = 1
     }
 
     makeSpanEventRecorder(stackId, sqlMetadataService) {
-        const recorder = new SpanEventRecorder(SpanEventBuilder.make(stackId), this.traceRoot, sqlMetadataService)
+        const recorder = new SpanEventRecorder(SpanEventBuilder.make(stackId), this.traceRoot, sqlMetadataService, this.exceptionEnricher)
         this.push(recorder.getSpanEventBuilder())
         return recorder
     }

--- a/lib/context/trace/child-trace-builder.js
+++ b/lib/context/trace/child-trace-builder.js
@@ -13,14 +13,14 @@ const serviceType = require('../../instrumentation/context/async-service-type')
 const defaultPredefinedMethodDescriptorRegistry = require('../../constant/default-predefined-method-descriptor-registry')
 
 class ChildTraceBuilder {
-    constructor(traceRoot, repository, localAsyncId, sqlMetadataService) {
+    constructor(traceRoot, repository, localAsyncId, sqlMetadataService, exceptionEnricher) {
         this.traceRoot = traceRoot
         this.repository = repository
         this.spanRecorder = new TraceRootSpanRecorder(traceRoot)
         this.localAsyncId = localAsyncId
         this.sqlMetadataService = sqlMetadataService
 
-        this.callStack = new CallStack(traceRoot)
+        this.callStack = new CallStack(traceRoot, exceptionEnricher)
         this.closed = false
 
         const spanEventRecorder = this.traceBlockBegin(StackId.asyncBeginStackId)

--- a/lib/context/trace/exception-enricher.js
+++ b/lib/context/trace/exception-enricher.js
@@ -1,0 +1,32 @@
+/**
+ * Pinpoint Node.js Agent
+ * Copyright 2020-present NAVER Corp.
+ * Apache License v2.0
+ */
+
+'use strict'
+
+const { ExceptionBuilder } = require('./exception-builder')
+
+class ExceptionEnricher {
+    constructor(config) {
+        this.config = config
+    }
+
+    recordException(spanEventBuilder, error) {
+        const exceptions = new ExceptionBuilder(error, this.config.getMaxDepth()).build()
+        spanEventBuilder.setException(exceptions)
+        if (exceptions.length > 0) {
+            spanEventBuilder.addAnnotation(exceptions[0].exceptionIdAnnotation())
+        }
+    }
+}
+
+const exceptionEnricherNullObject = Object.freeze({
+    recordException() {}
+})
+
+module.exports = {
+    ExceptionEnricher,
+    exceptionEnricherNullObject
+}

--- a/lib/context/trace/span-event-recorder.js
+++ b/lib/context/trace/span-event-recorder.js
@@ -13,7 +13,7 @@ const log = require('../../utils/log/logger')
 const AnnotationKeyUtils = require('../annotation-key-utils')
 const stringMetaService = require('../string-meta-service')
 const AsyncId = require('../async-id')
-const { ExceptionBuilder } = require('./exception-builder')
+const { exceptionEnricherNullObject } = require('./exception-enricher')
 
 class NullObjectSQLMetadataService {
     cacheSql() {
@@ -26,10 +26,11 @@ class SpanEventRecorder {
         return new SpanEventRecorder(SpanEventBuilder.nullObject(), traceRoot, new NullObjectSQLMetadataService())
     }
 
-    constructor(spanEventBuilder, traceRoot, sqlMetadataService) {
+    constructor(spanEventBuilder, traceRoot, sqlMetadataService, exceptionEnricher = exceptionEnricherNullObject) {
         this.spanEventBuilder = spanEventBuilder
         this.traceRoot = traceRoot
         this.sqlMetadataService = sqlMetadataService
+        this.exceptionEnricher = exceptionEnricher
     }
 
     getSpanEventBuilder() {
@@ -128,11 +129,7 @@ class SpanEventRecorder {
             shared.maskErrorCode(1)
         }
 
-        const exceptions = new ExceptionBuilder(error).build()
-        this.spanEventBuilder.setException(exceptions)
-        if (exceptions.length > 0) {
-            this.spanEventBuilder.addAnnotation(exceptions[0].exceptionIdAnnotation())
-        }
+        this.exceptionEnricher.recordException(this.spanEventBuilder, error)
     }
 
     recordSqlInfo(sql, bindString) {

--- a/lib/context/trace/trace.js
+++ b/lib/context/trace/trace.js
@@ -19,14 +19,15 @@ class Trace {
      * @param {Repository} repository - The repository for storing trace data.
      * @param {SpanRecorder} spanRecorder - The recorder for root span attributes.
      * @param {SqlMetadataService} sqlMetadataService - Service used to enrich span events with SQL metadata.
+     * @param {ExceptionEnricher} [exceptionEnricher] - Enricher for recording exception metadata.
      */
-    constructor(spanBuilder, repository, spanRecorder, sqlMetadataService) {
+    constructor(spanBuilder, repository, spanRecorder, sqlMetadataService, exceptionEnricher) {
         this.spanBuilder = spanBuilder
         this.repository = repository
         this.spanRecorder = spanRecorder
         this.sqlMetadataService = sqlMetadataService
 
-        this.callStack = new CallStack(spanBuilder.getTraceRoot())
+        this.callStack = new CallStack(spanBuilder.getTraceRoot(), exceptionEnricher)
         this.closed = false
     }
 

--- a/test/instrumentation/module/express.test.js
+++ b/test/instrumentation/module/express.test.js
@@ -993,6 +993,46 @@ test('express should record handler registered with pattern route', (t) => {
   })
 })
 
+test('express should not collect ExceptionMetaData when errorAnalysis is disabled', (t) => {
+  agent.bindHttp({
+    features: {
+      errorAnalysis: undefined
+    }
+  })
+
+  const app = new express()
+  const PATH = '/error-analysis-disabled'
+
+  app.get(PATH, (req, res, next) => {
+    agent.callbackTraceClose((trace) => {
+      setImmediate(() => {
+        const actualExceptionMetaData = trace.repository.dataSender.dataSender.actualExceptionMetaData
+        t.equal(actualExceptionMetaData, undefined, 'ExceptionMetaData should not be sent when errorAnalysis is disabled')
+
+        const spanEvent = trace.spanBuilder.spanEventList[1]
+        t.ok(spanEvent.exceptionInfo, 'exceptionInfo should still be recorded')
+        t.equal(spanEvent.exceptionInfo.intValue, 1, 'exceptionInfo intValue should be 1')
+        t.equal(spanEvent.exception, undefined, 'exception object should not be set')
+
+        server.close()
+        t.end()
+      })
+    })
+    next(new Error('error analysis disabled test'))
+  })
+  app.use(function (err, req, res, next) {
+    res.status(500).send('error')
+  })
+
+  const server = app.listen(TEST_ENV.port, async () => {
+    await axios.get(getServerUrl(PATH), {
+      validateStatus: () => true,
+      httpAgent: new http.Agent({ keepAlive: false }),
+      httpsAgent: new https.Agent({ keepAlive: false }),
+    })
+  })
+})
+
 test('express should disable uriTemplate/httpMethod enrichment and use null repository when isUriStatsEnabled is false', (t) => {
   t.plan(5)
 

--- a/test/instrumentation/module/koa.test.js
+++ b/test/instrumentation/module/koa.test.js
@@ -421,6 +421,53 @@ test('Should aggregate URI stats for DisableTrace in Koa', function (t) {
   })
 })
 
+test('Should not collect ExceptionMetaData when errorAnalysis is disabled in Koa', function (t) {
+  agent.bindHttp({
+    features: {
+      errorAnalysis: undefined
+    }
+  })
+
+  const PATH = '/integration/exception-disabled'
+  const app = new Koa()
+  const router = new Router()
+  let resolveTraceClosed
+  const traceClosed = new Promise((resolve) => {
+    resolveTraceClosed = resolve
+  })
+
+  router.get(PATH, async (ctx) => {
+    agent.callbackTraceClose((trace) => {
+      setImmediate(() => {
+        const actualExceptionMetaData = trace.repository.dataSender.dataSender.actualExceptionMetaData
+        t.equal(actualExceptionMetaData, undefined, 'ExceptionMetaData should not be sent when errorAnalysis is disabled')
+
+        resolveTraceClosed()
+      })
+    })
+    throw new Error('koa error analysis disabled test')
+  })
+
+  app.use(router.routes()).use(router.allowedMethods())
+
+  const server = app.listen(TEST_ENV.port, async () => {
+    try {
+      await axios.get(getServerUrl(PATH), {
+        timeout: 3000,
+        validateStatus: () => true,
+        httpAgent: new http.Agent({ keepAlive: false }),
+        httpsAgent: new https.Agent({ keepAlive: false }),
+      })
+      await traceClosed
+    } catch (e) {
+      t.fail(e)
+    } finally {
+      server.close()
+      t.end()
+    }
+  })
+})
+
 test('Should record ExceptionMetaData with uriTemplate when route throws in Koa', function (t) {
   agent.bindHttp()
 

--- a/test/instrumentation/module/undici.test.js
+++ b/test/instrumentation/module/undici.test.js
@@ -340,6 +340,44 @@ test('shimming undici: requestExceptionMetaData should deliver error.cause chain
     })
 })
 
+test('shimming undici: should not collect ExceptionMetaData when errorAnalysis is disabled', function (t) {
+    const originalEnv = process.env.PINPOINT_FEATURES_ERROR_ANALYSIS
+    process.env.PINPOINT_FEATURES_ERROR_ANALYSIS = 'false'
+
+    agent.bindHttp()
+
+    t.teardown(() => {
+        if (originalEnv === undefined) {
+            delete process.env.PINPOINT_FEATURES_ERROR_ANALYSIS
+        } else {
+            process.env.PINPOINT_FEATURES_ERROR_ANALYSIS = originalEnv
+        }
+    })
+
+    const app = new express()
+    app.get('/disabled-outgoing', (req, res) => {
+        agent.callbackTraceClose((trace) => {
+            setImmediate(() => {
+                const actualExceptionMetaData = trace.repository.dataSender.dataSender.actualExceptionMetaData
+                t.equal(actualExceptionMetaData, undefined, 'ExceptionMetaData should not be sent when errorAnalysis is disabled')
+                server.close()
+                t.end()
+            })
+        })
+        throw new Error('disabled error analysis test')
+    })
+    app.use(function (err, req, res, next) {
+        res.status(500).send('error')
+    })
+
+    const server = app.listen(5006, async () => {
+        await axios.get('http://localhost:5006/disabled-outgoing', {
+            validateStatus: () => true,
+            httpAgent: new http.Agent({ keepAlive: false }),
+        })
+    })
+})
+
 if (parseInt(process.versions.node.split('.')[0], 10) < 20) {
     test('node version 20 or higher specific test', function (t) {
         t.pass('This test runs only on Node.js version 20 or higher')

--- a/test/support/agent-singleton-mock.js
+++ b/test/support/agent-singleton-mock.js
@@ -22,8 +22,10 @@ const AgentInfo = require('../../lib/data/dto/agent-info')
 const { ConfigBuilder } = require('../../lib/config-builder')
 const { UriStatsRepositoryBuilder } = require('../../lib/metric/uri/uri-stats-repository')
 const { UriStatsConfigBuilder } = require('../../lib/metric/uri/uri-stats-config-builder')
-const { SpanRecorderEnricher } = require('../../lib/metric/uri/span-recorder-enricher')
+const { SpanRecorderEnricher, enricherNullObject } = require('../../lib/metric/uri/span-recorder-enricher')
 const { TraceCompletionEnricher } = require('../../lib/metric/uri/trace-completion-enricher')
+const { ErrorAnalysisConfigBuilder } = require('../../lib/context/trace/error-analysis-config-builder')
+const { ExceptionEnricher, exceptionEnricherNullObject } = require('../../lib/context/trace/exception-enricher')
 
 let traces = []
 const resetTraces = () => {
@@ -130,7 +132,9 @@ class MockAgent {
         this.traceContext.traceCompletionEnrichers = uriStatsConfig.isUriStatsEnabled()
             ? [new TraceCompletionEnricher(uriStatsRepository)]
             : []
-        this.traceContext.spanRecorderEnricher = uriStatsConfig.isUriStatsEnabled() ? new SpanRecorderEnricher(uriStatsConfig) : null
+        this.traceContext.spanRecorderEnricher = uriStatsConfig.isUriStatsEnabled() ? new SpanRecorderEnricher(uriStatsConfig) : enricherNullObject
+        const errorAnalysisConfig = new ErrorAnalysisConfigBuilder(config).build()
+        this.traceContext.spanEventEnricher = errorAnalysisConfig.isErrorAnalysisEnabled() ? new ExceptionEnricher(errorAnalysisConfig) : exceptionEnricherNullObject
 
         const dataSender = dataSenderMock(this.config, this.agentInfo, grpcDataSender)
         this.traceContext.dataSender = dataSender


### PR DESCRIPTION
## Summary

- Extract `ExceptionBuilder` logic from `SpanEventRecorder` into `ExceptionEnricher`
- When `errorAnalysis` config is disabled (no config or `enabled=false`), exception collection is skipped
- When enabled, `maxDepth` from config is passed to `ExceptionBuilder`
- Config flows: `index.js` → `TraceContext.spanEventEnricher` → `CallStack` → `SpanEventRecorder`
- Same enricher pattern as URI Stats (`SpanRecorderEnricher`)

## Test plan

- [x] Express 362 tests pass (incl. errorAnalysis disabled test)
- [x] Koa 61 tests pass (incl. errorAnalysis disabled test)
- [x] Undici 281 tests pass (incl. env var `PINPOINT_FEATURES_ERROR_ANALYSIS=false` test)
- [x] Total 704 tests pass

Closes #476