### PR TITLE
[#487] Refactor SpanRecorderEnricher as decorator and add SpanRecorderFactory

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ const { LogBuilder } = require('./lib/utils/log/log-builder')
 const logger = require('./lib/utils/log/logger')
 const { UriStatsMonitor } = require('./lib/metric/uri/uri-stats-monitor')
 const { UriStatsConfigBuilder } = require('./lib/metric/uri/uri-stats-config-builder')
-const { SpanRecorderEnricher } = require('./lib/metric/uri/span-recorder-enricher')
+const { UriStatsSpanRecorderFactory } = require('./lib/metric/uri/span-recorder-factory')
 const { UriStatsRepositoryBuilder } = require('./lib/metric/uri/uri-stats-repository')
 const { TraceCompletionEnricher } = require('./lib/metric/uri/trace-completion-enricher')
 const { ErrorAnalysisConfigBuilder } = require('./lib/context/trace/error-analysis-config-builder')
@@ -29,6 +29,7 @@ const agentBuilder = new AgentBuilder(agentInfo)
 
 const uriStatsConfig = new UriStatsConfigBuilder(config).build()
 if (uriStatsConfig.isUriStatsEnabled()) {
+    agentBuilder.setSpanRecorderFactory(new UriStatsSpanRecorderFactory(config, uriStatsConfig))
     const uriStatsRepository = new UriStatsRepositoryBuilder(uriStatsConfig).build()
     agentBuilder.addService((dataSender) => {
         const statsMonitor = new UriStatsMonitor(dataSender, uriStatsRepository)
@@ -39,7 +40,6 @@ if (uriStatsConfig.isUriStatsEnabled()) {
             }
         }
     })
-    agentBuilder.addEnricher(new SpanRecorderEnricher(uriStatsConfig))
     agentBuilder.addEnricher(new TraceCompletionEnricher(uriStatsRepository))
 }
 const errorAnalysisConfig = new ErrorAnalysisConfigBuilder(config).build()

--- a/lib/agent-builder.js
+++ b/lib/agent-builder.js
@@ -16,15 +16,16 @@ const Scheduler = require('./utils/scheduler')
 const AgentStatsMonitor = require('./metric/agent-stats-monitor')
 const PingScheduler = require('./metric/ping-scheduler')
 const { ConfigBuilder } = require('./config-builder')
+const { SpanRecorderFactory } = require('./metric/uri/span-recorder-factory')
 
 class Agent {
-    constructor(agentInfo, dataSender, config, logger, enrichers) {
+    constructor(agentInfo, dataSender, config, logger, enrichers, spanRecorderFactory) {
         this.agentInfo = agentInfo
         this.dataSender = dataSender
         this.config = config
         this.logger = logger
 
-        this.traceContext = new TraceContext(agentInfo, dataSender, config, enrichers)
+        this.traceContext = new TraceContext(agentInfo, dataSender, config, enrichers, spanRecorderFactory)
     }
 
     start() {
@@ -127,6 +128,11 @@ class AgentBuilder {
         return this
     }
 
+    setSpanRecorderFactory(spanRecorderFactory) {
+        this.spanRecorderFactory = spanRecorderFactory
+        return this
+    }
+
     build() {
         if (!this.config) {
             this.config = new ConfigBuilder().build()
@@ -135,7 +141,10 @@ class AgentBuilder {
         if (!this.dataSender) {
             this.dataSender = dataSenderFactory.create(this.config, this.agentInfo)
         }
-        const agent = new Agent(this.agentInfo, this.dataSender, this.config, this.logger ?? logger.getLogger(), this.enrichers)
+        if (!this.spanRecorderFactory) {
+            this.spanRecorderFactory = new SpanRecorderFactory(this.config)
+        }
+        const agent = new Agent(this.agentInfo, this.dataSender, this.config, this.logger ?? logger.getLogger(), this.enrichers, this.spanRecorderFactory)
 
         if (this.enableStatsMonitor || this.config.isStatsMonitoringEnabled()) {
             this.addService((dataSender) => {

--- a/lib/context/disable-span-recorder.js
+++ b/lib/context/disable-span-recorder.js
@@ -7,13 +7,11 @@
 'use strict'
 
 const annotationKey = require('../constant/annotation-key')
-const { enricherNullObject } = require('../metric/uri/span-recorder-enricher')
 
 class DisableSpanRecorder {
     constructor(traceRoot, config) {
         this.traceRoot = traceRoot
         this.httpStatusCodeErrors = config.getHttpStatusCodeErrors()
-        this.enricher = enricherNullObject
     }
 
     recordServiceType() {}
@@ -46,41 +44,22 @@ class DisableSpanRecorder {
 
     recordParentApplication() {}
 
-    recordEnricher(moduleName, ...args) {
-        this.enricher.record(moduleName, ...args)
-    }
+    recordEnricher() {}
 }
 
 class NullDisableSpanRecorder {
-    constructor() {
-        this.enricher = enricherNullObject
-    }
-
     recordServiceType() {}
-
     recordApiId() {}
-
     recordApi() {}
-
     setApiId0() {}
-
     recordAttribute() {}
-
     recordRpc() {}
-
     recordEndPoint() {}
-
     recordRemoteAddress() {}
-
     recordException() {}
-
     recordAcceptorHost() {}
-
     recordParentApplication() {}
-
-    recordEnricher(moduleName, ...args) {
-        this.enricher.record(moduleName, ...args)
-    }
+    recordEnricher() {}
 }
 
 DisableSpanRecorder.nullObject = new NullDisableSpanRecorder()

--- a/lib/context/trace-context.js
+++ b/lib/context/trace-context.js
@@ -20,21 +20,19 @@ const DisableChildTrace = require('./trace/disable-child-trace')
 const disableAsyncId = require('./trace/disable-async-id')
 const activeRequestRepository = require('../metric/active-request-repository')
 const { SqlMetadataService } = require('../instrumentation/sql/sql-metadata-service')
-const SpanRecorder = require('./trace/span-recorder')
-const DisableSpanRecorder = require('./disable-span-recorder')
 const SpanEventRecorderFactory = require('./trace/span-event-recorder-factory')
 
 class TraceContext {
-  constructor(agentInfo, dataSender, config, enrichers = []) {
+  constructor(agentInfo, dataSender, config, enrichers = [], spanRecorderFactory) {
     this.agentInfo = agentInfo
     this.dataSender = dataSender
     this.config = config
     this.traceSampler = new TraceSampler(agentInfo, config)
     this.sqlMetadataService = new SqlMetadataService(dataSender, config)
     this.traceCompletionEnrichers = enrichers.filter(e => typeof e.onComplete === 'function')
-    this.spanRecorderEnricher = enrichers.find(e => typeof e.record === 'function')
     this.spanEventEnricher = enrichers.find(e => typeof e.recordException === 'function')
     this.spanEventRecorderFactory = new SpanEventRecorderFactory(this.sqlMetadataService, this.spanEventEnricher)
+    this.spanRecorderFactory = spanRecorderFactory
   }
 
   getAgentInfo() {
@@ -78,10 +76,7 @@ class TraceContext {
 
   newLocalTrace(traceRoot) {
     activeRequestRepository.register(traceRoot)
-    const spanRecorder = new DisableSpanRecorder(traceRoot, this.config)
-    if (this.spanRecorderEnricher) {
-      spanRecorder.enricher = this.spanRecorderEnricher
-    }
+    const spanRecorder = this.spanRecorderFactory.createDisable(traceRoot)
     return new DisableTrace(traceRoot, spanRecorder)
   }
 
@@ -104,10 +99,7 @@ class TraceContext {
       .setApplicationServiceType(this.agentInfo.getApplicationServiceType())
     const repository = new SpanRepository(spanChunkBuilder, this.dataSender)
     activeRequestRepository.register(traceRoot)
-    const spanRecorder = new SpanRecorder(spanBuilder, this.config)
-    if (this.spanRecorderEnricher) {
-      spanRecorder.enricher = this.spanRecorderEnricher
-    }
+    const spanRecorder = this.spanRecorderFactory.create(spanBuilder)
     return new Trace(spanBuilder, repository, spanRecorder, this.spanEventRecorderFactory)
   }
 

--- a/lib/context/trace/span-recorder.js
+++ b/lib/context/trace/span-recorder.js
@@ -8,13 +8,11 @@
 
 const annotationKey = require('../../constant/annotation-key')
 const Annotations = require('../../instrumentation/context/annotation/annotations')
-const { enricherNullObject } = require('../../metric/uri/span-recorder-enricher')
 
 class SpanRecorder {
     constructor(spanBuilder, config) {
         this.spanBuilder = spanBuilder
         this.httpStatusCodeErrors = config.getHttpStatusCodeErrors()
-        this.enricher = enricherNullObject
     }
 
     recordServiceType(code) {
@@ -103,9 +101,7 @@ class SpanRecorder {
         this.spanBuilder.setParentApplicationType(parentApplicationType)
     }
 
-    recordEnricher(moduleName, ...args) {
-        this.enricher.record(moduleName, ...args)
-    }
+    recordEnricher() {}
 }
 
 module.exports = SpanRecorder

--- a/lib/instrumentation/http-shared.js
+++ b/lib/instrumentation/http-shared.js
@@ -27,7 +27,7 @@ exports.instrumentRequest = function (agent) {
         // https://nodejs.org/api/stream.html#streamfinishedstream-options-callback
         finished(res, function (err) {
           const spanRecorder = trace.getSpanRecorder()
-          spanRecorder.recordEnricher('http', trace.getTraceRoot(), req)
+          spanRecorder.recordEnricher('http', req)
 
           if (err) {
             const end = res.end

--- a/lib/instrumentation/module/express/express-layer-interceptor.js
+++ b/lib/instrumentation/module/express/express-layer-interceptor.js
@@ -75,7 +75,7 @@ class ExpressLayerInterceptor {
                     }
 
                     const spanRecorder = trace.getSpanRecorder()
-                    spanRecorder.recordEnricher('express', trace.getTraceRoot(), request)
+                    spanRecorder.recordEnricher('express', request)
                 }
             }, this, arguments)
         }

--- a/lib/instrumentation/module/koa/koa-register-interceptor.js
+++ b/lib/instrumentation/module/koa/koa-register-interceptor.js
@@ -58,7 +58,7 @@ class KoaRegisterInterceptor {
                     }
 
                     const spanRecorder = trace.getSpanRecorder()
-                    spanRecorder.recordEnricher('koa', trace.getTraceRoot(), path, method)
+                    spanRecorder.recordEnricher('koa', path, method)
                 }
                 result = await fn.apply(this, arguments)
             } catch (e) {

--- a/lib/metric/uri/span-recorder-enricher.js
+++ b/lib/metric/uri/span-recorder-enricher.js
@@ -7,60 +7,67 @@
 'use strict'
 
 class SpanRecorderEnricher {
-    constructor(config) {
+    constructor(spanRecorder, config, traceRoot) {
+        this.spanRecorder = spanRecorder
         this.config = config
+        this.traceRoot = traceRoot
     }
 
-    record(moduleName, traceRoot, ...args) {
+    recordServiceType(code) { this.spanRecorder.recordServiceType(code) }
+    recordApiId(apiId) { this.spanRecorder.recordApiId(apiId) }
+    recordApi(methodDescriptor) { this.spanRecorder.recordApi(methodDescriptor) }
+    setApiId0(apiId) { this.spanRecorder.setApiId0(apiId) }
+    recordAttribute(key, value) { this.spanRecorder.recordAttribute(key, value) }
+    recordRpc(rpc) { this.spanRecorder.recordRpc(rpc) }
+    recordEndPoint(endPoint) { this.spanRecorder.recordEndPoint(endPoint) }
+    recordRemoteAddress(remoteAddr) { this.spanRecorder.recordRemoteAddress(remoteAddr) }
+    recordException(error, markError) { this.spanRecorder.recordException(error, markError) }
+    recordAcceptorHost(host) { this.spanRecorder.recordAcceptorHost(host) }
+    recordParentApplication(parentApplicationName, parentApplicationType) { this.spanRecorder.recordParentApplication(parentApplicationName, parentApplicationType) }
+
+    recordEnricher(moduleName, ...args) {
         if (!args || args.length < 1) {
             return
         }
 
         if (moduleName === 'http' && this.config.isUriStatsUseUserInput()) {
             const req = args[0]
-            this.setUriTemplate(traceRoot, req['pinpoint.metric.uri-template'], true)
+            this.setUriTemplate(req['pinpoint.metric.uri-template'], true)
         } else if (moduleName === 'express') {
             const req = args[0]
-            this.setUriTemplate(traceRoot, req.route?.path, false)
+            this.setUriTemplate(req.route?.path, false)
             if (this.config.isUriStatsHttpMethodEnabled()) {
-                this.setUriHttpMethod(traceRoot, req.method)
+                this.setUriHttpMethod(req.method)
             }
         } else if (moduleName === 'koa') {
-            this.setUriTemplate(traceRoot, args[0], false)
+            this.setUriTemplate(args[0], false)
             if (this.config.isUriStatsHttpMethodEnabled()) {
-                this.setUriHttpMethod(traceRoot, args[1])
+                this.setUriHttpMethod(args[1])
             }
         }
     }
 
-    setUriTemplate(traceRoot, uriTemplate, force) {
+    setUriTemplate(uriTemplate, force) {
         if (typeof uriTemplate !== 'string' || uriTemplate.length < 1) {
             return
         }
 
-        if (!force && traceRoot.getEnricher('uriStats.uriTemplate')) {
+        if (!force && this.traceRoot.getEnricher('uriStats.uriTemplate')) {
             return
         }
 
-        traceRoot.setEnricher('uriStats.uriTemplate', uriTemplate)
+        this.traceRoot.setEnricher('uriStats.uriTemplate', uriTemplate)
     }
 
-    setUriHttpMethod(traceRoot, httpMethod) {
+    setUriHttpMethod(httpMethod) {
         if (typeof httpMethod !== 'string' || httpMethod.length === 0) {
             return
         }
 
-        traceRoot.setEnricher('uriStats.method', httpMethod)
+        this.traceRoot.setEnricher('uriStats.method', httpMethod)
     }
 }
 
-const enricherNullObject = Object.freeze({
-    record() {
-
-    }
-})
-
 module.exports = {
-    SpanRecorderEnricher,
-    enricherNullObject
+    SpanRecorderEnricher
 }

--- a/lib/metric/uri/span-recorder-factory.js
+++ b/lib/metric/uri/span-recorder-factory.js
@@ -1,0 +1,44 @@
+/**
+ * Pinpoint Node.js Agent
+ * Copyright 2020-present NAVER Corp.
+ * Apache License v2.0
+ */
+
+'use strict'
+
+const SpanRecorder = require('../../context/trace/span-recorder')
+const DisableSpanRecorder = require('../../context/disable-span-recorder')
+const { SpanRecorderEnricher } = require('./span-recorder-enricher')
+
+class SpanRecorderFactory {
+    constructor(config) {
+        this.config = config
+    }
+
+    create(spanBuilder) {
+        return new SpanRecorder(spanBuilder, this.config)
+    }
+
+    createDisable(traceRoot) {
+        return new DisableSpanRecorder(traceRoot, this.config)
+    }
+}
+
+class UriStatsSpanRecorderFactory extends SpanRecorderFactory {
+    constructor(config, uriStatsConfig) {
+        super(config)
+        this.uriStatsConfig = uriStatsConfig
+    }
+
+    create(spanBuilder) {
+        const spanRecorder = super.create(spanBuilder)
+        return new SpanRecorderEnricher(spanRecorder, this.uriStatsConfig, spanBuilder.getTraceRoot())
+    }
+
+    createDisable(traceRoot) {
+        const spanRecorder = super.createDisable(traceRoot)
+        return new SpanRecorderEnricher(spanRecorder, this.uriStatsConfig, traceRoot)
+    }
+}
+
+module.exports = { SpanRecorderFactory, UriStatsSpanRecorderFactory }

--- a/test/context/trace-context.test.js
+++ b/test/context/trace-context.test.js
@@ -12,12 +12,13 @@ const defaultPredefinedMethodDescriptorRegistry = require('../../lib/constant/de
 const localStorage = require('../../lib/instrumentation/context/local-storage')
 const agent = require('../support/agent-singleton-mock')
 const TraceIdBuilder = require('../../lib/context/trace/trace-id-builder')
+const { SpanRecorderFactory } = require('../../lib/metric/uri/span-recorder-factory')
 
 test('Should create continued trace and add span info', function (t) {
   t.plan(2)
   agent.bindHttp()
 
-  const traceContext = new TraceContext(agent.agentInfo, agent.dataSender, agent.config)
+  const traceContext = new TraceContext(agent.agentInfo, agent.dataSender, agent.config, [], new SpanRecorderFactory(agent.config))
   const traceId = new TraceIdBuilder(agent.agentInfo.getAgentId(), agent.agentInfo.getAgentStartTime(), '9').build()
   const trace = traceContext.continueTraceObject(traceId)
   localStorage.run(trace, () => {
@@ -36,7 +37,7 @@ test('Should begin/end trace block asynchronously', async function (t) {
   agent.bindHttp()
 
   // start trace and write span info
-  const traceContext = new TraceContext(agent.agentInfo, agent.dataSender, agent.config)
+  const traceContext = new TraceContext(agent.agentInfo, agent.dataSender, agent.config, [], new SpanRecorderFactory(agent.config))
   const startedTrace = traceContext.newTraceObject('/')
 
   localStorage.run(startedTrace, () => {
@@ -66,7 +67,7 @@ test('Should begin/end trace block asynchronously', async function (t) {
 test('Should complete trace ', async function (t) {
   t.plan(1)
   agent.bindHttp()
-  const traceContext = new TraceContext(agent.agentInfo, agent.dataSender, agent.config)
+  const traceContext = new TraceContext(agent.agentInfo, agent.dataSender, agent.config, [], new SpanRecorderFactory(agent.config))
   const trace = traceContext.newTraceObject('/')
 
   await new Promise(resolve => setTimeout(resolve, 501))

--- a/test/support/agent-singleton-mock.js
+++ b/test/support/agent-singleton-mock.js
@@ -22,7 +22,7 @@ const AgentInfo = require('../../lib/data/dto/agent-info')
 const { ConfigBuilder } = require('../../lib/config-builder')
 const { UriStatsRepositoryBuilder } = require('../../lib/metric/uri/uri-stats-repository')
 const { UriStatsConfigBuilder } = require('../../lib/metric/uri/uri-stats-config-builder')
-const { SpanRecorderEnricher, enricherNullObject } = require('../../lib/metric/uri/span-recorder-enricher')
+const { SpanRecorderFactory, UriStatsSpanRecorderFactory } = require('../../lib/metric/uri/span-recorder-factory')
 const { TraceCompletionEnricher } = require('../../lib/metric/uri/trace-completion-enricher')
 const { ErrorAnalysisConfigBuilder } = require('../../lib/context/trace/error-analysis-config-builder')
 const { ExceptionEnricher, exceptionEnricherNullObject } = require('../../lib/context/trace/exception-enricher')
@@ -94,13 +94,14 @@ const config = new ConfigBuilder({
     .setDefaultJson(require('../pinpoint-config-test.json'))
     .build()
 const agentInfo = AgentInfo.make(config)
+const initialUriStatsConfig = new UriStatsConfigBuilder(config).build()
 const agentBuilder = new AgentBuilder(agentInfo)
     .setConfig(config)
     .setDataSender(dataSenderMock(config, agentInfo))
     .disablePingScheduler()
     .disableStatsScheduler()
-    .addEnricher(new SpanRecorderEnricher(new UriStatsConfigBuilder(config).build()))
-    .addEnricher(new TraceCompletionEnricher(new UriStatsRepositoryBuilder(new UriStatsConfigBuilder(config).build()).build()))
+    .setSpanRecorderFactory(new UriStatsSpanRecorderFactory(config, initialUriStatsConfig))
+    .addEnricher(new TraceCompletionEnricher(new UriStatsRepositoryBuilder(initialUriStatsConfig).build()))
 const agent = agentBuilder.build()
 
 class MockAgent {
@@ -133,7 +134,9 @@ class MockAgent {
         this.traceContext.traceCompletionEnrichers = uriStatsConfig.isUriStatsEnabled()
             ? [new TraceCompletionEnricher(uriStatsRepository)]
             : []
-        this.traceContext.spanRecorderEnricher = uriStatsConfig.isUriStatsEnabled() ? new SpanRecorderEnricher(uriStatsConfig) : enricherNullObject
+        this.traceContext.spanRecorderFactory = uriStatsConfig.isUriStatsEnabled()
+            ? new UriStatsSpanRecorderFactory(config, uriStatsConfig)
+            : new SpanRecorderFactory(config)
         const errorAnalysisConfig = new ErrorAnalysisConfigBuilder(config).build()
         this.traceContext.spanEventEnricher = errorAnalysisConfig.isErrorAnalysisEnabled() ? new ExceptionEnricher(errorAnalysisConfig) : exceptionEnricherNullObject
 


### PR DESCRIPTION
## Summary

- Convert `SpanRecorderEnricher` to decorator pattern wrapping `SpanRecorder`
- Add `SpanRecorderFactory` (default) and `UriStatsSpanRecorderFactory` (decorator)
- Remove `enricher` member variable and `enricherNullObject` from `SpanRecorder` and `DisableSpanRecorder`
- Instrumentation modules no longer pass `traceRoot` to `recordEnricher()`
- Part of #477

## Test plan

- [x] Total 835 tests pass

Closes #487