### PR TITLE
[#489] Add Claude Code local settings to .gitignore and reorganize Git Rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ checkstyle-results.xml
 
 # coverage
 .nyc_output
+
+# claude code
+**/.claude/**/*.local.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -65,10 +65,19 @@ TypeScript declarations are in `index.d.ts` and per-module `.d.ts` files; genera
 
 ## Git Rules
 
-- **One commit per PR**: Before committing, squash all changes into a single commit using `git commit` (not amend). If multiple commits exist on the branch, squash them before pushing.
+### Workflow
+
+1. **New task**: Create a GitHub issue first via `gh issue create` if one does not exist. Always assign a milestone to issues and PRs.
+2. **Branch**: Create a feature branch from master.
+3. **Code changes**: Implement the feature or fix.
+4. **Testing**: New features and bug fixes must include functional tests for all supported web frameworks (Express, Koa, Next.js). Run relevant test files and confirm they pass.
+5. **Review**: Stop and wait for the user to review the diff. Do not proceed until the user explicitly approves.
+6. **Commit and push**: Squash all changes into a single commit using `git commit` (not amend). Push the branch to remote.
+7. **PR**: Create a pull request via `gh pr create`.
+8. **After PR merge**: `git fetch upstream` → `git checkout master` → `git rebase upstream/master` → `git push origin master` → delete feature branch locally and remotely.
+
+### Commit conventions
+
 - **Commit message format**: `[#ISSUE_NUMBER] Short description` followed by a concise body explaining what and why.
 - **No Co-Authored-By lines**: Do not append `Co-Authored-By` trailers to commit messages.
-- **Testing**: New features and bug fixes must include functional tests for all supported web frameworks (Express, Koa, Next.js). Run relevant test files and confirm they pass before committing.
 - **All documentation in English**: Commit messages, PR descriptions, issue bodies, review comments, and any GitHub-facing content must be written in English. Keep concise with bullet points, and update PR descriptions via `gh pr edit` when pushing changes that alter scope.
-- **After PR merge**: `git fetch upstream` → `git checkout master` → `git rebase upstream/master` → `git push origin master` → delete feature branch locally and remotely.
-- **New tasks**: When starting a new feature or issue without an existing GitHub issue, create one first via `gh issue create`. Always assign a milestone to issues and PRs.


### PR DESCRIPTION
## Summary
- Add `**/.claude/**/*.local.json` pattern to `.gitignore` to prevent Claude Code local settings from being tracked
- Reorganize CLAUDE.md Git Rules into Workflow (step-by-step) and Commit conventions subsections

## Changes
### .gitignore
- Add `**/.claude/**/*.local.json` pattern

### CLAUDE.md
- Restructure Git Rules into ordered Workflow steps (issue → branch → code → test → review → commit/push → PR → post-merge cleanup)
- Separate Commit conventions (message format, no Co-Authored-By, English documentation)

## Test plan
- [x] Verify `.claude/settings.local.json` is ignored by git
- [x] Verify CLAUDE.md renders correctly