### PR TITLE
[#491] Add Claude Code worktrees directory to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,3 +45,4 @@ checkstyle-results.xml
 
 # claude code
 **/.claude/**/*.local.json
+**/.claude/worktrees/


### PR DESCRIPTION
## Summary
- Add `**/.claude/worktrees/` pattern to `.gitignore` to prevent Claude Code worktree directories from being tracked in git

## Test plan
- [x] Verify `.claude/worktrees/` directory is ignored by git