### PR TITLE
[#500] Extract CompositeTraceCompletionEnricher and inject into TraceContext via AgentBuilder

### DIFF
--- a/lib/agent-builder.js
+++ b/lib/agent-builder.js
@@ -20,15 +20,16 @@ const { SpanRecorderFactory } = require('./context/trace/span-recorder-factory')
 const { SqlMetadataService } = require('./instrumentation/sql/sql-metadata-service')
 const { IntIdParsingResultFactory } = require('./context/trace/parsing-result-factory')
 const SpanEventRecorderFactory = require('./context/trace/span-event-recorder-factory')
+const { CompositeTraceCompletionEnricher } = require('./context/trace/composite-trace-completion-enricher')
 
 class Agent {
-    constructor(agentInfo, dataSender, config, logger, enrichers, spanRecorderFactory, spanEventRecorderFactory) {
+    constructor(agentInfo, dataSender, config, logger, traceCompletionEnricher, spanRecorderFactory, spanEventRecorderFactory) {
         this.agentInfo = agentInfo
         this.dataSender = dataSender
         this.config = config
         this.logger = logger
 
-        this.traceContext = new TraceContext(agentInfo, dataSender, config, enrichers, spanRecorderFactory, spanEventRecorderFactory)
+        this.traceContext = new TraceContext(agentInfo, dataSender, config, traceCompletionEnricher, spanRecorderFactory, spanEventRecorderFactory)
     }
 
     start() {
@@ -156,7 +157,8 @@ class AgentBuilder {
         const sqlMetadataService = new SqlMetadataService(this.dataSender, parsingResultFactory)
         const exceptionSpanEventEnricher = this.enrichers.find(e => typeof e.recordException === 'function')
         const spanEventRecorderFactory = new SpanEventRecorderFactory(sqlMetadataService, exceptionSpanEventEnricher)
-        const agent = new Agent(this.agentInfo, this.dataSender, this.config, this.logger ?? logger.getLogger(), this.enrichers, this.spanRecorderFactory, spanEventRecorderFactory)
+        const traceCompletionEnricher = CompositeTraceCompletionEnricher.make(this.enrichers)
+        const agent = new Agent(this.agentInfo, this.dataSender, this.config, this.logger ?? logger.getLogger(), traceCompletionEnricher, this.spanRecorderFactory, spanEventRecorderFactory)
 
         if (this.enableStatsMonitor || this.config.isStatsMonitoringEnabled()) {
             this.addService((dataSender) => {

--- a/lib/context/trace-context.js
+++ b/lib/context/trace-context.js
@@ -20,12 +20,12 @@ const DisableChildTrace = require('./trace/disable-child-trace')
 const disableAsyncId = require('./trace/disable-async-id')
 const activeRequestRepository = require('../metric/active-request-repository')
 class TraceContext {
-  constructor(agentInfo, dataSender, config, enrichers = [], spanRecorderFactory, spanEventRecorderFactory) {
+  constructor(agentInfo, dataSender, config, traceCompletionEnricher, spanRecorderFactory, spanEventRecorderFactory) {
     this.agentInfo = agentInfo
     this.dataSender = dataSender
     this.config = config
     this.traceSampler = new TraceSampler(agentInfo, config)
-    this.traceCompletionEnrichers = enrichers.filter(e => typeof e.onComplete === 'function')
+    this.traceCompletionEnricher = traceCompletionEnricher
     this.spanEventRecorderFactory = spanEventRecorderFactory
     this.spanRecorderFactory = spanRecorderFactory
   }
@@ -45,13 +45,7 @@ class TraceContext {
 
     try {
       const traceCloseTime = trace.close()
-      for (const enricher of this.traceCompletionEnrichers) {
-        try {
-          enricher.onComplete(trace, traceCloseTime)
-        } catch (e) {
-          log.error('enricher failed', e)
-        }
-      }
+      this.traceCompletionEnricher.onComplete(trace, traceCloseTime)
 
       activeRequestRepository.remove(trace.getTraceRoot())
     } catch (e) {

--- a/lib/context/trace/composite-trace-completion-enricher.js
+++ b/lib/context/trace/composite-trace-completion-enricher.js
@@ -1,0 +1,33 @@
+/**
+ * Pinpoint Node.js Agent
+ * Copyright 2020-present NAVER Corp.
+ * Apache License v2.0
+ */
+
+'use strict'
+
+const log = require('../../utils/log/logger')
+
+class CompositeTraceCompletionEnricher {
+    constructor(enrichers) {
+        this.enrichers = enrichers
+    }
+
+    static make(enrichers = []) {
+        return new CompositeTraceCompletionEnricher(
+            enrichers.filter(e => typeof e.onComplete === 'function')
+        )
+    }
+
+    onComplete(trace, traceCloseTime) {
+        for (const enricher of this.enrichers) {
+            try {
+                enricher.onComplete(trace, traceCloseTime)
+            } catch (e) {
+                log.error('enricher failed', e)
+            }
+        }
+    }
+}
+
+module.exports = { CompositeTraceCompletionEnricher }

--- a/test/context/trace-context.test.js
+++ b/test/context/trace-context.test.js
@@ -16,12 +16,13 @@ const { SpanRecorderFactory } = require('../../lib/context/trace/span-recorder-f
 const SpanEventRecorderFactory = require('../../lib/context/trace/span-event-recorder-factory')
 const { SqlMetadataService } = require('../../lib/instrumentation/sql/sql-metadata-service')
 const { IntIdParsingResultFactory } = require('../../lib/context/trace/parsing-result-factory')
+const { CompositeTraceCompletionEnricher } = require('../../lib/context/trace/composite-trace-completion-enricher')
 
 test('Should create continued trace and add span info', function (t) {
   t.plan(2)
   agent.bindHttp()
 
-  const traceContext = new TraceContext(agent.agentInfo, agent.dataSender, agent.config, [], new SpanRecorderFactory(agent.config), new SpanEventRecorderFactory(new SqlMetadataService(agent.dataSender, new IntIdParsingResultFactory())))
+  const traceContext = new TraceContext(agent.agentInfo, agent.dataSender, agent.config, new CompositeTraceCompletionEnricher([]), new SpanRecorderFactory(agent.config), new SpanEventRecorderFactory(new SqlMetadataService(agent.dataSender, new IntIdParsingResultFactory())))
   const traceId = new TraceIdBuilder(agent.agentInfo.getAgentId(), agent.agentInfo.getAgentStartTime(), '9').build()
   const trace = traceContext.continueTraceObject(traceId)
   localStorage.run(trace, () => {
@@ -40,7 +41,7 @@ test('Should begin/end trace block asynchronously', async function (t) {
   agent.bindHttp()
 
   // start trace and write span info
-  const traceContext = new TraceContext(agent.agentInfo, agent.dataSender, agent.config, [], new SpanRecorderFactory(agent.config), new SpanEventRecorderFactory(new SqlMetadataService(agent.dataSender, new IntIdParsingResultFactory())))
+  const traceContext = new TraceContext(agent.agentInfo, agent.dataSender, agent.config, new CompositeTraceCompletionEnricher([]), new SpanRecorderFactory(agent.config), new SpanEventRecorderFactory(new SqlMetadataService(agent.dataSender, new IntIdParsingResultFactory())))
   const startedTrace = traceContext.newTraceObject('/')
 
   localStorage.run(startedTrace, () => {
@@ -70,7 +71,7 @@ test('Should begin/end trace block asynchronously', async function (t) {
 test('Should complete trace ', async function (t) {
   t.plan(1)
   agent.bindHttp()
-  const traceContext = new TraceContext(agent.agentInfo, agent.dataSender, agent.config, [], new SpanRecorderFactory(agent.config), new SpanEventRecorderFactory(new SqlMetadataService(agent.dataSender, new IntIdParsingResultFactory())))
+  const traceContext = new TraceContext(agent.agentInfo, agent.dataSender, agent.config, new CompositeTraceCompletionEnricher([]), new SpanRecorderFactory(agent.config), new SpanEventRecorderFactory(new SqlMetadataService(agent.dataSender, new IntIdParsingResultFactory())))
   const trace = traceContext.newTraceObject('/')
 
   await new Promise(resolve => setTimeout(resolve, 501))

--- a/test/instrumentation/module/express.test.js
+++ b/test/instrumentation/module/express.test.js
@@ -33,10 +33,10 @@ const TEST_ENV = {
 const getServerUrl = (path) => `http://${TEST_ENV.host}:${TEST_ENV.port}${path}`
 
 const getUriStatsRepository = () => {
-  const traceCompletionEnricher = agent.traceContext?.traceCompletionEnrichers?.find((enricher) => {
-    return enricher && typeof enricher.onComplete === 'function' && enricher.repository
+  const enricher = agent.traceContext?.traceCompletionEnricher?.enrichers?.find((e) => {
+    return e && typeof e.onComplete === 'function' && e.repository
   })
-  return traceCompletionEnricher?.repository ?? UriStatsRepositoryBuilder.nullObject
+  return enricher?.repository ?? UriStatsRepositoryBuilder.nullObject
 }
 
 const testName1 = 'express1'

--- a/test/instrumentation/module/koa.test.js
+++ b/test/instrumentation/module/koa.test.js
@@ -29,10 +29,10 @@ const TEST_ENV = {
 const getServerUrl = (path) => `http://${TEST_ENV.host}:${TEST_ENV.port}${path}`
 
 const getUriStatsRepository = () => {
-  const traceCompletionEnricher = agent.traceContext?.traceCompletionEnrichers?.find((enricher) => {
-    return enricher && typeof enricher.onComplete === 'function' && enricher.repository
+  const enricher = agent.traceContext?.traceCompletionEnricher?.enrichers?.find((e) => {
+    return e && typeof e.onComplete === 'function' && e.repository
   })
-  return traceCompletionEnricher?.repository ?? UriStatsRepositoryBuilder.nullObject
+  return enricher?.repository ?? UriStatsRepositoryBuilder.nullObject
 }
 
 const testName1 = 'koa-router1'

--- a/test/support/agent-singleton-mock.js
+++ b/test/support/agent-singleton-mock.js
@@ -31,6 +31,7 @@ const { TraceCompletionEnricher } = require('../../lib/metric/uri/trace-completi
 const { ErrorAnalysisConfigBuilder } = require('../../lib/context/trace/error-analysis-config-builder')
 const { ExceptionEnricher, exceptionEnricherNullObject } = require('../../lib/context/trace/exception-enricher')
 const SpanEventRecorderFactory = require('../../lib/context/trace/span-event-recorder-factory')
+const { CompositeTraceCompletionEnricher } = require('../../lib/context/trace/composite-trace-completion-enricher')
 
 let traces = []
 const resetTraces = () => {
@@ -135,9 +136,9 @@ class MockAgent {
 
         this.traceContext.traceSampler = new TraceSampler(this.agentInfo, config)
         this.traceContext.config = config
-        this.traceContext.traceCompletionEnrichers = uriStatsConfig.isUriStatsEnabled()
-            ? [new TraceCompletionEnricher(uriStatsRepository)]
-            : []
+        this.traceContext.traceCompletionEnricher = uriStatsConfig.isUriStatsEnabled()
+            ? new CompositeTraceCompletionEnricher([new TraceCompletionEnricher(uriStatsRepository)])
+            : new CompositeTraceCompletionEnricher([])
         this.traceContext.spanRecorderFactory = uriStatsConfig.isUriStatsEnabled()
             ? new UriStatsSpanRecorderFactory(config, uriStatsConfig)
             : new SpanRecorderFactory(config)


### PR DESCRIPTION
## Summary
- Create `CompositeTraceCompletionEnricher` with `static make()` factory that encapsulates enricher filtering
- `AgentBuilder` assembles `CompositeTraceCompletionEnricher` and injects into `TraceContext`
- `TraceContext` delegates to single `onComplete()` call instead of iterating array
- Hides array implementation detail from `TraceContext`

Closes #500

## Test plan
- [x] trace-context tests pass (7/7)
- [x] Express tests pass (362/362)
- [x] Koa tests pass (61/61)