### PR TITLE
[#502] Release 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,15 @@
 # Changelog
 All notable changes to Pinpoint Node.js agent will be documented in this file.
 
+## [1.4.1] - 2026-03-31
+### Changed
+- [[#478](https://github.com/pinpoint-apm/pinpoint-node-agent/issues/478)] Documented `pinpoint-config.json` format changes for migration to v1.4. See the [migration guide](https://github.com/pinpoint-apm/pinpoint-node-agent?tab=readme-ov-file#migrating-pinpoint-configjson-to-v14) for details.
+
+### Improvements
+- [[#477](https://github.com/pinpoint-apm/pinpoint-node-agent/issues/477)] Refactored enricher system — `AgentBuilder` now assembles all dependencies and injects into `TraceContext`
+- [[#498](https://github.com/pinpoint-apm/pinpoint-node-agent/issues/498)] Extracted `ParsingResultFactory` to decouple SQL metadata from global config
+- [[#500](https://github.com/pinpoint-apm/pinpoint-node-agent/issues/500)] Extracted `CompositeTraceCompletionEnricher` to encapsulate trace completion lifecycle
+
 ## [1.4.0] - 2026-03-25
 ### Fixed
 - [[#474](https://github.com/pinpoint-apm/pinpoint-node-agent/issues/474)] Replace external `end-of-stream` dependency with Node.js built-in `stream.finished()`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,6 +76,16 @@ TypeScript declarations are in `index.d.ts` and per-module `.d.ts` files; genera
 7. **PR**: Create a pull request via `gh pr create`. Include `Closes #ISSUE_NUMBER` in the PR body to link the issue.
 8. **After PR merge**: `git fetch upstream` → `git checkout master` → `git rebase upstream/master` → `git push origin master` → delete feature branch locally and remotely.
 
+### Release procedure
+
+1. Create a release issue (e.g., "Release 1.4.1") with a checklist: update CHANGELOG.md, bump `version` in `package.json` and `demo/express/package.json`, update version assertion in `test/agent.test.js`, memory leak test, npm publish, git tag, GitHub Release.
+2. Update CHANGELOG.md with release notes and migration guide links.
+3. Bump version in `package.json`, `demo/express/package.json`, and `test/agent.test.js`.
+4. After PR merge, run memory leak test and post results as a comment on the release issue.
+5. `npm publish` and verify on npmjs.com.
+6. `git tag <version>` → `git push upstream <version>`.
+7. Create GitHub Release from the tag with release notes from CHANGELOG.md.
+
 ### Commit conventions
 
 - **Commit message format**: `[#ISSUE_NUMBER] Short description` followed by a concise body explaining what and why.

--- a/demo/express/package.json
+++ b/demo/express/package.json
@@ -20,6 +20,6 @@
     "mysql": "^2.18.1",
     "mysql2": "^3.9.1",
     "pg": "^8.16.2",
-    "pinpoint-node-agent": "^1.0.0"
+    "pinpoint-node-agent": "^1.4.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pinpoint-node-agent",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "type": "commonjs",
   "main": "./index.js",
   "types": "./index.d.ts",

--- a/test/agent.test.js
+++ b/test/agent.test.js
@@ -11,5 +11,5 @@ test('Should initialize agent', function (t) {
 
   const agent = require('./support/agent-singleton-mock')
   t.ok(agent)
-  t.equal(agent.agentInfo.agentVersion, '1.4.0', 'agent version from package.json')
+  t.equal(agent.agentInfo.agentVersion, '1.4.1', 'agent version from package.json')
 })


### PR DESCRIPTION
## Summary
- Add v1.4.1 release notes to CHANGELOG.md with migration guide link
- Add Improvements section for internal refactoring changes
- Bump version to 1.4.1 in package.json and demo/express/package.json
- Update agent version assertion in test
- Add release procedure to CLAUDE.md

Closes #502

## Test plan
- [x] Verify CHANGELOG.md renders correctly
- [x] Verify package.json version is 1.4.1
- [x] Full test suite pass (2785/2785)