### PR TITLE
[#505] Fix UNKNOWN_DATABASE in MySQL pool.getConnection query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to Pinpoint Node.js agent will be documented in this file.
 
 ## [1.4.1] - 2026-03-31
+### Fixed
+- [[#505](https://github.com/pinpoint-apm/pinpoint-node-agent/issues/505)] Fix `UNKNOWN_DATABASE` shown for MySQL `pool.getConnection` → `connection.query` path
+
 ### Changed
 - [[#478](https://github.com/pinpoint-apm/pinpoint-node-agent/issues/478)] Documented `pinpoint-config.json` format changes for migration to v1.4. See the [migration guide](https://github.com/pinpoint-apm/pinpoint-node-agent?tab=readme-ov-file#migrating-pinpoint-configjson-to-v14) for details.
 

--- a/lib/instrumentation/instrument-method.js
+++ b/lib/instrumentation/instrument-method.js
@@ -52,10 +52,11 @@ class InstrumentMethod {
                     if (recorder && arguments.length > 0 && typeof interceptor.callbackIndexOf === 'function' && typeof interceptor.callbackIndexOf(arguments) === 'number') {
                         const asyncId = recorder.getNextAsyncId()
                         const callbackIndex = interceptor.callbackIndexOf(arguments)
+                        const targetThis = this
                         shimmer.wrap(arguments, callbackIndex, function (original) {
                             return function () {
                                 try {
-                                    interceptor.prepareBeforeAsyncTrace?.(this, arguments)
+                                    interceptor.prepareBeforeAsyncTrace?.(targetThis, arguments)
                                 } catch (error) {
                                     log.error(`arguments: ${error}`)
                                 }

--- a/lib/instrumentation/module/mysql/mysql-cluster-get-connection-interceptor.js
+++ b/lib/instrumentation/module/mysql/mysql-cluster-get-connection-interceptor.js
@@ -1,0 +1,39 @@
+/**
+ * Pinpoint Node.js Agent
+ * Copyright 2020-present NAVER Corp.
+ * Apache License v2.0
+ */
+
+'use strict'
+
+const databaseInfoSymbol = require('./mysql-database-information-symbol')
+const MySQLGetConnectionInterceptor = require('./mysql-get-connection-interceptor')
+
+class MySQLClusterGetConnectionInterceptor {
+    constructor(traceContext) {
+        this.delegate = new MySQLGetConnectionInterceptor(traceContext)
+    }
+
+    prepareBeforeAsyncTrace(target, args) {
+        if (args.length > 1 && args[1]) {
+            const connection = args[1]
+            if (connection.config) {
+                target[databaseInfoSymbol] = {
+                    host: connection.config.host,
+                    database: connection.config.database
+                }
+            }
+        }
+        this.delegate.prepareBeforeAsyncTrace(target, args)
+    }
+
+    doInAfterTrace(recorder) {
+        this.delegate.doInAfterTrace(recorder)
+    }
+
+    callbackIndexOf(args) {
+        return this.delegate.callbackIndexOf(args)
+    }
+}
+
+module.exports = MySQLClusterGetConnectionInterceptor

--- a/lib/instrumentation/module/mysql/mysql-cluster-of-interceptor.js
+++ b/lib/instrumentation/module/mysql/mysql-cluster-of-interceptor.js
@@ -8,7 +8,7 @@
 
 const MethodDescriptorBuilder = require('../../../context/method-descriptor-builder')
 const InstrumentMethod = require('../../instrument-method')
-const MySQLGetConnectionInterceptor = require('./mysql-get-connection-interceptor')
+const MySQLClusterGetConnectionInterceptor = require('./mysql-cluster-get-connection-interceptor')
 const apiMetaService = require('../../../context/api-meta-service')
 const mysqlServiceType = require('./mysql-service-type')
 
@@ -25,7 +25,7 @@ class MySQLClusterOfInterceptor {
         if (!poolNamespace) {
             return
         }
-        InstrumentMethod.make(poolNamespace, 'getConnection', this.traceContext).addScopedInterceptor(new MySQLGetConnectionInterceptor(this.traceContext))
+        InstrumentMethod.make(poolNamespace, 'getConnection', this.traceContext).addScopedInterceptor(new MySQLClusterGetConnectionInterceptor(this.traceContext))
     }
 
     doInAfterTrace(recorder) {

--- a/lib/instrumentation/module/mysql/mysql-get-connection-interceptor.js
+++ b/lib/instrumentation/module/mysql/mysql-get-connection-interceptor.js
@@ -24,8 +24,9 @@ class MySQLGetConnectionInterceptor {
     }
 
     prepareBeforeAsyncTrace(target, args) {
-        if (args.length > 1 && args[1]) {
+        if (args.length > 1 && args[1] && target) {
             const connection = args[1]
+            connection[databaseInfoSymbol] = target[databaseInfoSymbol]
             InstrumentMethod.make(connection, 'query', this.traceContext).addScopedInterceptor(new MySQLStatementExecuteQueryInterceptor('PoolConnection'))
         }
     }

--- a/test/instrumentation/module/mysql.test.js
+++ b/test/instrumentation/module/mysql.test.js
@@ -315,6 +315,7 @@ test(`Connection Pool with query`, async (t) => {
             t.equal(actualSpanEvent.depth, 1, 'Pool.getConnection spanEvent depth')
             t.equal(actualSpanEvent.sequence, 1, 'Pool.getConnection spanEvent sequence')
             t.equal(actualSpanEvent.serviceType, mysqlServiceType.getCode(), 'Pool.getConnection spanEvent serviceType')
+            t.equal(actualSpanEvent.destinationId, 'test', 'Pool.getConnection spanEvent destinationId')
 
             let actualSpanChunk = trace.repository.dataSender.findSpanChunk(actualSpanEvent.asyncId)
             t.equal(actualSpanChunk.spanId, actualSpanEvent.spanId, 'spanChunk spanId')
@@ -334,6 +335,7 @@ test(`Connection Pool with query`, async (t) => {
             t.equal(actualSpanEvent.depth, 2, 'PoolConnection.query spanEvent depth on pool.query')
             t.equal(actualSpanEvent.sequence, 1, 'PoolConnection.query spanEvent sequence on pool.query')
             t.equal(actualSpanEvent.serviceType, mysqlExecuteQueryServiceType.getCode(), 'PoolConnection.query spanEvent serviceType on pool.query')
+            t.equal(actualSpanEvent.destinationId, 'test', 'PoolConnection.query spanEvent destinationId on pool.query via getConnection')
 
             asyncSpanChunkMySQLMatcher(t, trace, actualSpanEvent)
 
@@ -345,6 +347,7 @@ test(`Connection Pool with query`, async (t) => {
             t.equal(actualSpanEvent.depth, 1, 'Pool.getConnection spanEvent depth on pool.query')
             t.equal(actualSpanEvent.sequence, 2, 'Pool.getConnection spanEvent sequence on pool.query')
             t.equal(actualSpanEvent.serviceType, mysqlExecuteQueryServiceType.getCode(), 'PoolConnection.query spanEvent serviceType on pool.query')
+            t.equal(actualSpanEvent.destinationId, 'test', 'PoolConnection.query spanEvent destinationId on pool.query direct')
 
             actualSpanChunk = trace.repository.dataSender.findSpanChunk(actualSpanEvent.asyncId)
             t.equal(actualSpanChunk.spanId, actualSpanEvent.spanId, 'spanChunk spanId on pool.query')
@@ -469,6 +472,7 @@ test(`Cluster with query`, async (t) => {
             t.equal(actualSpanEvent.depth, 2, 'PoolConnection.query spanEvent depth in poolCluster.getConnection')
             t.equal(actualSpanEvent.sequence, 1, 'PoolConnection.query spanEvent sequence in poolCluster.getConnection')
             t.equal(actualSpanEvent.serviceType, mysqlExecuteQueryServiceType.getCode(), 'PoolConnection.query spanEvent serviceType in poolCluster.getConnection')
+            t.equal(actualSpanEvent.destinationId, 'test', 'PoolConnection.query spanEvent destinationId in poolCluster.getConnection')
 
             asyncSpanChunkMySQLMatcher(t, trace, actualSpanEvent)
             t.end()


### PR DESCRIPTION
## Summary
- Fix `instrument-method.js` to pass outer target (Pool) to `prepareBeforeAsyncTrace` instead of callback's `this` (PoolConnection)
- Propagate `databaseInfoSymbol` from Pool to PoolConnection in `MySQLGetConnectionInterceptor`
- Create `MySQLClusterGetConnectionInterceptor` decorator to extract database info from `PoolConnection.config` for cluster path
- Add `destinationId` assertions for Pool.getConnection, PoolConnection.query and PoolCluster.getConnection span events
- Add Fixed section to CHANGELOG.md for v1.4.1

Closes #505

## Test plan
- [x] MySQL tests pass (159/159)
- [x] Express tests pass (362/362)
- [x] Koa tests pass (61/61)