### PR TITLE
[#511] Add source checkout step to report-coverage workflow

### DIFF
--- a/.github/workflows/report-coverage.yml
+++ b/.github/workflows/report-coverage.yml
@@ -13,6 +13,10 @@ jobs:
       pull-requests: write
       issues: write
     steps:
+      - name: Checkout source code
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.workflow_run.head_sha }}
       - name: Download coverage artifact
         uses: actions/download-artifact@v4
         with:


### PR DESCRIPTION
## Summary

- Add `actions/checkout@v3` step to `report-coverage.yml` to checkout source code at the triggering workflow's commit SHA
- `genhtml` requires source files to generate annotated HTML coverage reports, but only the `lcov.info` artifact was being downloaded

Closes #511

## Test plan

- [x] YAML syntax validated