### PR TITLE
[#513] Disable report workflows until PR comment via artifact is implemented

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,23 +26,24 @@ jobs:
           node-version: ${{ matrix.node_version }}
       - run: npm install
       - run: npm test
-      - name: Lint
-        if: matrix.node_version == env.TARGET_NODE_VERSION
-        run: npm run lint
-      - name: Upload checkstyle result
-        if: matrix.node_version == env.TARGET_NODE_VERSION
-        uses: actions/upload-artifact@v4
-        with:
-          name: checkstyle-result
-          path: checkstyle-result.xml
-          retention-days: 1
-      - name: Coverage
-        if: matrix.node_version == env.TARGET_NODE_VERSION
-        run: npm run coverage
-      - name: Upload coverage result
-        if: matrix.node_version == env.TARGET_NODE_VERSION
-        uses: actions/upload-artifact@v4
-        with:
-          name: coverage-report
-          path: coverage/lcov.info
-          retention-days: 1
+      # TODO: Re-enable after implementing PR comment via artifact (#513)
+      # - name: Lint
+      #   if: matrix.node_version == env.TARGET_NODE_VERSION
+      #   run: npm run lint
+      # - name: Upload checkstyle result
+      #   if: matrix.node_version == env.TARGET_NODE_VERSION
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: checkstyle-result
+      #     path: checkstyle-result.xml
+      #     retention-days: 1
+      # - name: Coverage
+      #   if: matrix.node_version == env.TARGET_NODE_VERSION
+      #   run: npm run coverage
+      # - name: Upload coverage result
+      #   if: matrix.node_version == env.TARGET_NODE_VERSION
+      #   uses: actions/upload-artifact@v4
+      #   with:
+      #     name: coverage-report
+      #     path: coverage/lcov.info
+      #     retention-days: 1

--- a/.github/workflows/report-checkstyle.yml
+++ b/.github/workflows/report-checkstyle.yml
@@ -1,25 +1,26 @@
+# TODO: Re-enable after implementing PR comment via artifact (#513)
 name: Report Checkstyle
 
-on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+# on:
+#   workflow_run:
+#     workflows: ["CI"]
+#     types: [completed]
 
-jobs:
-  report:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    permissions:
-      checks: write
-    steps:
-      - name: Download checkstyle artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: checkstyle-result
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Upload checkstyle report
-        uses: jwgmeligmeyling/checkstyle-github-action@master
-        with:
-          path: 'checkstyle-result.xml'
-          token: ${{ secrets.GITHUB_TOKEN }}
+# jobs:
+#   report:
+#     runs-on: ubuntu-latest
+#     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+#     permissions:
+#       checks: write
+#     steps:
+#       - name: Download checkstyle artifact
+#         uses: actions/download-artifact@v4
+#         with:
+#           name: checkstyle-result
+#           run-id: ${{ github.event.workflow_run.id }}
+#           github-token: ${{ secrets.GITHUB_TOKEN }}
+#       - name: Upload checkstyle report
+#         uses: jwgmeligmeyling/checkstyle-github-action@master
+#         with:
+#           path: 'checkstyle-result.xml'
+#           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/report-coverage.yml
+++ b/.github/workflows/report-coverage.yml
@@ -1,36 +1,37 @@
+# TODO: Re-enable after implementing PR comment via artifact (#513)
 name: Report Coverage
 
-on:
-  workflow_run:
-    workflows: ["CI"]
-    types: [completed]
+# on:
+#   workflow_run:
+#     workflows: ["CI"]
+#     types: [completed]
 
-jobs:
-  report:
-    runs-on: ubuntu-latest
-    if: ${{ github.event.workflow_run.conclusion == 'success' }}
-    permissions:
-      pull-requests: write
-      issues: write
-    steps:
-      - name: Checkout source code
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ github.event.workflow_run.head_sha }}
-      - name: Download coverage artifact
-        uses: actions/download-artifact@v4
-        with:
-          name: coverage-report
-          run-id: ${{ github.event.workflow_run.id }}
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup LCOV
-        uses: hrishikesh-kadam/setup-lcov@v1
-        with:
-          ref: v1.16
-      - name: Report code coverage
-        uses: zgosalvez/github-actions-report-lcov@v4
-        with:
-          coverage-files: lcov.info
-          artifact-name: code-coverage-report
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          update-comment: true
+# jobs:
+#   report:
+#     runs-on: ubuntu-latest
+#     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+#     permissions:
+#       pull-requests: write
+#       issues: write
+#     steps:
+#       - name: Checkout source code
+#         uses: actions/checkout@v3
+#         with:
+#           ref: ${{ github.event.workflow_run.head_sha }}
+#       - name: Download coverage artifact
+#         uses: actions/download-artifact@v4
+#         with:
+#           name: coverage-report
+#           run-id: ${{ github.event.workflow_run.id }}
+#           github-token: ${{ secrets.GITHUB_TOKEN }}
+#       - name: Setup LCOV
+#         uses: hrishikesh-kadam/setup-lcov@v1
+#         with:
+#           ref: v1.16
+#       - name: Report code coverage
+#         uses: zgosalvez/github-actions-report-lcov@v4
+#         with:
+#           coverage-files: lcov.info
+#           artifact-name: code-coverage-report
+#           github-token: ${{ secrets.GITHUB_TOKEN }}
+#           update-comment: true


### PR DESCRIPTION
## Summary
- Comment out lint, checkstyle upload, and coverage upload steps in CI workflow
- Comment out triggers and jobs in report-checkstyle and report-coverage workflows
- `workflow_run` event runs in default branch context without PR info, so current report actions cannot comment on PRs
- Will be re-enabled after implementing PR number artifact approach

Closes #513